### PR TITLE
Update fp_js_validator.js

### DIFF
--- a/Resources/public/js/fp_js_validator.js
+++ b/Resources/public/js/fp_js_validator.js
@@ -696,7 +696,11 @@ var FpJsFormValidator = new function () {
      */
     this.findParentForm = function (child) {
         if ('form' == child.tagName.toLowerCase()) {
-            return child;
+            if ((callerChild.jsFormValidator != undefined)
+        		&& (child.jsFormValidator == undefined)) {
+        		child.jsFormValidator = callerChild.jsFormValidator;
+        		return child;
+        	}
         } else if (child.parentNode) {
             return this.findParentForm(child.parentNode);
         } else {


### PR DESCRIPTION
- FpJsFormValidator.js and fp_js_validator.js (line 697):
  In Symfony 2.4.1, the form id (FormTypeInterface::getName) is passed to the div that contains the fields instead of the form. The .jsFormValidator attribute is created on the div, but is not passed to the form, which is the DOM parent node of the div, so the client validation never runs because .jsFormValidator doesn't exist (see lines 779 of both files).

SubscriberToQueue.php (line 52):
The older validation was only taking forms that their FormTypeInterface::getName() returns "form". Using a custom name there would always avoid the form to be added in the queue.
