### PR TITLE
Update SubscriberToQueue.php

### DIFF
--- a/Form/Subscriber/SubscriberToQueue.php
+++ b/Form/Subscriber/SubscriberToQueue.php
@@ -49,10 +49,7 @@ class SubscriberToQueue implements EventSubscriberInterface
         // Add only parent forms which are not disabled
         if ($globalSwitch && $localSwitch) {
             $parent = $this->getParent($form);
-            if (
-                !$this->factory->inQueue($parent) &&
-                'form' == $parent->getConfig()->getType()->getInnerType()->getName()
-            ) {
+            if (!$this->factory->inQueue($parent)) {
                 $this->factory->addToQueue($this->getParent($form));
             }
         }


### PR DESCRIPTION
- FpJsFormValidator.js and fp_js_validator.js (line 697):
  In Symfony 2.4.1, the form id (FormTypeInterface::getName) is passed to the div that contains the fields instead of the form. The .jsFormValidator attribute is created on the div, but is not passed to the form, which is the DOM parent node of the div, so the client validation never runs because .jsFormValidator doesn't exist (see lines 779 of both files).

SubscriberToQueue.php (line 52):
The older validation was only taking forms that their FormTypeInterface::getName() returns "form". Using a custom name there would always avoid the form to be added in the queue.
