### PR TITLE
Update FpJsFormValidator.js

### DIFF
--- a/Resources/public/js/FpJsFormValidator.js
+++ b/Resources/public/js/FpJsFormValidator.js
@@ -695,10 +695,15 @@ var FpJsFormValidator = new function () {
      * @return {HTMLElement|null}
      */
     this.findParentForm = function (child) {
+        this.findParentForm = function (child, callerChild) {
         if ('form' == child.tagName.toLowerCase()) {
-            return child;
+        	if ((callerChild.jsFormValidator != undefined)
+            	&& (child.jsFormValidator == undefined)) {
+            	child.jsFormValidator = callerChild.jsFormValidator;
+            	return child;
+            }
         } else if (child.parentNode) {
-            return this.findParentForm(child.parentNode);
+        	return this.findParentForm(child.parentNode, callerChild);
         } else {
             return null;
         }


### PR DESCRIPTION
The correct code
- FpJsFormValidator.js and fp_js_validator.js (line 697):
  In Symfony 2.4.1, the form id (FormTypeInterface::getName) is passed to the div that contains the fields instead of the form. The .jsFormValidator attribute is created on the div, but is not passed to the form, which is the DOM parent node of the div, so the client validation never runs because .jsFormValidator doesn't exist (see lines 779 of both files).
