### PR TITLE
Only run unique constraint checks on the constraint fields 2

### DIFF
--- a/Resources/public/js/FpJsFormValidator.js
+++ b/Resources/public/js/FpJsFormValidator.js
@@ -233,7 +233,7 @@ function FpJsCustomizeMethods() {
                 if (data['entity'] && data['entity']['constraints']) {
                     for (var i in data['entity']['constraints']) {
                         var constraint = data['entity']['constraints'][i];
-                        if (constraint instanceof FpJsFormValidatorBundleFormConstraintUniqueEntity && constraint.fields.indexOf(item.name) > -1) {
+                        if (constraint instanceof FpJsFormValidatorBundleFormConstraintUniqueEntity && constraint.fields.indexOf(item.jsFormValidator.name) > -1) {
                             var owner = item.jsFormValidator.parent;
                             constraint.validate(null, owner);
                         }


### PR DESCRIPTION
`item.name` refers to `<form_name>[<field_name>]` - `item.jsFormValidator.name` holds the value to be matched.

Sorry I didn't catch it the first time: before the check passed when it shouldn't have and currently it fails when it shouldn't...