### PR TITLE
allow empty dates, fixes #33

### DIFF
--- a/Resources/public/js/fp_js_validator.js
+++ b/Resources/public/js/fp_js_validator.js
@@ -2170,15 +2170,20 @@ function SymfonyComponentFormExtensionCoreDataTransformerDateTimeToArrayTransfor
     };
 
     this.twoDigits = function(value) {
+        if ('' === value[0]) {
+            return '';
+        }
+
         return ('0' + value).slice(-2);
     };
 
     this.formatDate = function(format, date) {
+        if ('' === date.join('')) {
+            return '';
+        }
+
         return format.replace(/{(\d+)}/g, function(match, number) {
-            return typeof date[number] != 'undefined'
-                ? date[number]
-                : match
-            ;
+            return typeof date[number] != 'undefined' ? date[number] : match;
         });
     }
 }

--- a/Tests/javascript/constraints/DateSpec.js
+++ b/Tests/javascript/constraints/DateSpec.js
@@ -1,0 +1,32 @@
+describe('SymfonyComponentValidatorConstraintsDate', function() {
+    var constraint;
+
+    before(function() {
+        constraint = new SymfonyComponentValidatorConstraintsDate();
+        constraint.message = '{{ value }} is not a valid date';
+    });
+
+    context('an invalid date format', function() {
+        it('returns an array of errors', function() {
+            var errors = constraint.validate('not-a-date');
+
+            expect(errors).to.deep.equal(['not-a-date is not a valid date']);
+        });
+    });
+
+    context('an empty value', function() {
+        it('returns an empty array', function() {
+            var errors = constraint.validate('');
+
+            expect(errors).to.be.empty;
+        });
+    });
+
+    context('a valid date', function() {
+        it('returns an empty array', function() {
+            var errors = constraint.validate('2002-03-04');
+
+            expect(errors).to.be.empty;
+        });
+    });
+});

--- a/Tests/javascript/transformer/DateTimeToArraySpec.js
+++ b/Tests/javascript/transformer/DateTimeToArraySpec.js
@@ -1,0 +1,33 @@
+describe('SymfonyComponentFormExtensionCoreDataTransformerDateTimeToArrayTransformer', function() {
+    var transformer;
+
+    before(function() {
+        transformer = new SymfonyComponentFormExtensionCoreDataTransformerDateTimeToArrayTransformer();
+    });
+
+    describe('#reverseTransform', function() {
+        context('a date', function() {
+            it('returns a date string', function() {
+                var result = transformer.reverseTransform({ year: ["2012"], month: ["2"], day: ["4"] });
+
+                expect(result).to.equal('2012-02-04');
+            });
+        });
+
+        context('an empty date', function() {
+            it('returns empty string', function() {
+                var result = transformer.reverseTransform({ year: [""], month: [""], day: [""] });
+
+                expect(result).to.equal('');
+            });
+        });
+
+        context('a datetime', function() {
+            it('returns a datetime string', function() {
+                var result = transformer.reverseTransform({ year: ["2002"], month: ["12"], day: ["3"], hour: ["4"], minute: ["43"], second: ["59"] });
+
+                expect(result).to.equal('2002-12-03 04:43:59');
+            });
+        });
+    });
+});

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,66 @@
+// Karma configuration
+// Generated on Wed Apr 29 2015 11:40:41 GMT+0200 (CEST)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'chai'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'Resources/public/js/fp_js_validator.js',
+      'Tests/javascript/**/*Spec.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "JsFormValidatorBundle",
+  "version": "1.2.1",
+  "description": "The Javascript validation for sf2 forms",
+  "main": "index.js",
+  "scripts": {
+    "test": "./karma start"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hanneskaeufler/JsFormValidatorBundle.git"
+  },
+  "author": "",
+  "license": "Copyright (C) 2014 by Forma-Pro",
+  "bugs": {
+    "url": "https://github.com/hanneskaeufler/JsFormValidatorBundle/issues"
+  },
+  "homepage": "https://github.com/hanneskaeufler/JsFormValidatorBundle",
+  "devDependencies": {
+    "chai": "^2.3.0",
+    "karma": "^0.12.31",
+    "karma-chai": "^0.1.0",
+    "karma-chrome-launcher": "^0.1.8",
+    "karma-mocha": "^0.1.10",
+    "mocha": "^2.2.4"
+  }
+}


### PR DESCRIPTION
This pr fixes issue #33, which makes empty dates valid if the field is not required.

It also adds karma as a test runner for javascript tests, so smaller fixes to constraints, transformers etc. do not have to be verified with slow functional tests.

You need to

``` shell
npm install -g karma-cli && npm install && karma start
```

to run the tests. We could also use the PhantomJS to run those specs with travis.
