### PR TITLE
Fix Travis CI build & Correct value parameter in violation messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_script:
   - Tests/app/switch_sf_version.sh "$SF_VERSION"
   - composer require "symfony/symfony:${SF_VERSION}"
   - composer install -n
+  - composer info -i
 
   - Tests/app/console assets:install Tests/app
   - sudo chmod -R 0777 Tests/app/cache Tests/app/logs
@@ -30,7 +31,7 @@ before_script:
   - sudo sed -i -e "s,/var/www,$(pwd)/Tests/app,g" /etc/apache2/sites-available/default
   - sudo /etc/init.d/apache2 restart
 
-  - vendor/bin/selenium-server-standalone > selenium.log &
+  - vendor/bin/selenium-server-standalone &> selenium.log &
   - sleep 4
 
 script: phpunit -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: php
 php: [5.3]
 
 env:
-  - SF_VERSION='~2.3.0'
-  - SF_VERSION='~2.4.0'
-  - SF_VERSION='>=2.5,<2.5.3'
+  - SF_VERSION='~2.3.0,>=2.3.19'
+  - SF_VERSION='~2.4.0,>=2.4.9'
+  - SF_VERSION='~2.5.0,>=2.5.3,<=2.5.4'
 
 before_script:
   - export WEB_FIXTURES_HOST=http://localhost/index.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ before_script:
   - sudo sed -i -e "s,/var/www,$(pwd)/Tests/app,g" /etc/apache2/sites-available/default
   - sudo /etc/init.d/apache2 restart
 
-  - curl http://selenium.googlecode.com/files/selenium-server-standalone-2.35.0.jar > selenium.jar
-  - java -jar selenium.jar > selenium.log &
+  - vendor/bin/selenium-server-standalone > selenium.log &
   - sleep 4
 
 script: phpunit -v

--- a/Resources/public/js/FpJsFormValidator.js
+++ b/Resources/public/js/FpJsFormValidator.js
@@ -335,6 +335,31 @@ var FpJsBaseConstraint = {
         }
 
         return realMsg;
+    },
+
+    formatValue: function (value) {
+        switch (Object.prototype.toString.call(value)) {
+            case '[object Date]':
+                return value.format('Y-m-d H:i:s');
+
+            case '[object Object]':
+                return 'object';
+
+            case '[object Array]':
+                return 'array';
+
+            case '[object String]':
+                return '"' + value + '"';
+
+            case '[object Null]':
+                return 'null';
+
+            case '[object Boolean]':
+                return value ? 'true' : 'false';
+
+            default:
+                return String(value);
+        }
     }
 };
 

--- a/Resources/public/js/constraints/Blank.js
+++ b/Resources/public/js/constraints/Blank.js
@@ -12,7 +12,7 @@ function SymfonyComponentValidatorConstraintsBlank() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/Choice.js
+++ b/Resources/public/js/constraints/Choice.js
@@ -29,7 +29,10 @@ function SymfonyComponentValidatorConstraintsChoice() {
         if (this.multiple) {
             if (invalidCnt) {
                 while (invalidCnt--) {
-                    errors.push(this.multipleMessage.replace('{{ value }}', String(invalidList[invalidCnt])));
+                    errors.push(this.multipleMessage.replace(
+                        '{{ value }}',
+                        FpJsBaseConstraint.formatValue(invalidList[invalidCnt])
+                    ));
                 }
             }
             if (!isNaN(this.min) && value.length < this.min) {
@@ -40,7 +43,10 @@ function SymfonyComponentValidatorConstraintsChoice() {
             }
         } else if (invalidCnt) {
             while (invalidCnt--) {
-                errors.push(this.message.replace('{{ value }}', String(invalidList[invalidCnt])));
+                errors.push(this.message.replace(
+                    '{{ value }}',
+                    FpJsBaseConstraint.formatValue(invalidList[invalidCnt])
+                ));
             }
         }
 
@@ -53,12 +59,12 @@ function SymfonyComponentValidatorConstraintsChoice() {
 
         this.minMessage = FpJsBaseConstraint.prepareMessage(
             this.minMessage,
-            {'{{ limit }}': this.min},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.min)},
             this.min
         );
         this.maxMessage = FpJsBaseConstraint.prepareMessage(
             this.maxMessage,
-            {'{{ limit }}': this.max},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.max)},
             this.max
         );
     };

--- a/Resources/public/js/constraints/Count.js
+++ b/Resources/public/js/constraints/Count.js
@@ -42,17 +42,17 @@ function SymfonyComponentValidatorConstraintsCount() {
 
         this.minMessage = FpJsBaseConstraint.prepareMessage(
             this.minMessage,
-            {'{{ limit }}': this.min},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.min)},
             this.min
         );
         this.maxMessage = FpJsBaseConstraint.prepareMessage(
             this.maxMessage,
-            {'{{ limit }}': this.max},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.max)},
             this.max
         );
         this.exactMessage = FpJsBaseConstraint.prepareMessage(
             this.exactMessage,
-            {'{{ limit }}': this.min},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.min)},
             this.min
         );
     }

--- a/Resources/public/js/constraints/Date.js
+++ b/Resources/public/js/constraints/Date.js
@@ -13,7 +13,7 @@ function SymfonyComponentValidatorConstraintsDate() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/DateTime.js
+++ b/Resources/public/js/constraints/DateTime.js
@@ -13,7 +13,7 @@ function SymfonyComponentValidatorConstraintsDateTime() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/Email.js
+++ b/Resources/public/js/constraints/Email.js
@@ -13,7 +13,7 @@ function SymfonyComponentValidatorConstraintsEmail() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/EqualTo.js
+++ b/Resources/public/js/constraints/EqualTo.js
@@ -15,7 +15,7 @@ function SymfonyComponentValidatorConstraintsEqualTo() {
         if (!f.isValueEmty(value) && this.value != value) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', String(this.value))
+                    .replace('{{ value }}', String(value))
                     .replace('{{ compared_value }}', String(this.value))
                     .replace('{{ compared_value_type }}', String(this.value))
             );

--- a/Resources/public/js/constraints/EqualTo.js
+++ b/Resources/public/js/constraints/EqualTo.js
@@ -15,9 +15,9 @@ function SymfonyComponentValidatorConstraintsEqualTo() {
         if (!f.isValueEmty(value) && this.value != value) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ compared_value }}', String(this.value))
-                    .replace('{{ compared_value_type }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
+                    .replace('{{ compared_value_type }}', FpJsBaseConstraint.formatValue(this.value))
             );
         }
 

--- a/Resources/public/js/constraints/False.js
+++ b/Resources/public/js/constraints/False.js
@@ -10,7 +10,7 @@ function SymfonyComponentValidatorConstraintsFalse() {
     this.validate = function (value) {
         var errors = [];
         if ('' !== value && false !== value) {
-            errors.push(this.message.replace('{{ value }}', value));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/GreaterThan.js
+++ b/Resources/public/js/constraints/GreaterThan.js
@@ -15,7 +15,7 @@ function SymfonyComponentValidatorConstraintsGreaterThan() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(this.value))
+                    .replace('{{ value }}', String(value))
                     .replace('{{ compared_value }}', String(this.value))
             ];
         }

--- a/Resources/public/js/constraints/GreaterThan.js
+++ b/Resources/public/js/constraints/GreaterThan.js
@@ -15,8 +15,8 @@ function SymfonyComponentValidatorConstraintsGreaterThan() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ compared_value }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
             ];
         }
     }

--- a/Resources/public/js/constraints/GreaterThanOrEqual.js
+++ b/Resources/public/js/constraints/GreaterThanOrEqual.js
@@ -15,7 +15,7 @@ function SymfonyComponentValidatorConstraintsGreaterThanOrEqual() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(this.value))
+                    .replace('{{ value }}', String(value))
                     .replace('{{ compared_value }}', String(this.value))
             ];
         }

--- a/Resources/public/js/constraints/GreaterThanOrEqual.js
+++ b/Resources/public/js/constraints/GreaterThanOrEqual.js
@@ -15,8 +15,8 @@ function SymfonyComponentValidatorConstraintsGreaterThanOrEqual() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ compared_value }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
             ];
         }
     }

--- a/Resources/public/js/constraints/IdenticalTo.js
+++ b/Resources/public/js/constraints/IdenticalTo.js
@@ -13,9 +13,9 @@ function SymfonyComponentValidatorConstraintsIdenticalTo() {
         if ('' !== value && this.value !== value) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ compared_value }}', String(this.value))
-                    .replace('{{ compared_value_type }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
+                    .replace('{{ compared_value_type }}', FpJsBaseConstraint.formatValue(this.value))
             );
         }
 

--- a/Resources/public/js/constraints/Ip.js
+++ b/Resources/public/js/constraints/Ip.js
@@ -13,7 +13,7 @@ function SymfonyComponentValidatorConstraintsIp() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/Length.js
+++ b/Resources/public/js/constraints/Length.js
@@ -38,17 +38,17 @@ function SymfonyComponentValidatorConstraintsLength() {
 
         this.minMessage = FpJsBaseConstraint.prepareMessage(
             this.minMessage,
-            {'{{ limit }}': this.min},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.min)},
             this.min
         );
         this.maxMessage = FpJsBaseConstraint.prepareMessage(
             this.maxMessage,
-            {'{{ limit }}': this.max},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.max)},
             this.max
         );
         this.exactMessage = FpJsBaseConstraint.prepareMessage(
             this.exactMessage,
-            {'{{ limit }}': this.min},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.min)},
             this.min
         );
     }

--- a/Resources/public/js/constraints/LessThan.js
+++ b/Resources/public/js/constraints/LessThan.js
@@ -15,7 +15,7 @@ function SymfonyComponentValidatorConstraintsLessThan() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(this.value))
+                    .replace('{{ value }}', String(value))
                     .replace('{{ compared_value }}', String(this.value))
             ];
         }

--- a/Resources/public/js/constraints/LessThan.js
+++ b/Resources/public/js/constraints/LessThan.js
@@ -15,8 +15,8 @@ function SymfonyComponentValidatorConstraintsLessThan() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ compared_value }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
             ];
         }
     }

--- a/Resources/public/js/constraints/LessThanOrEqual.js
+++ b/Resources/public/js/constraints/LessThanOrEqual.js
@@ -15,7 +15,7 @@ function SymfonyComponentValidatorConstraintsLessThanOrEqual() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(this.value))
+                    .replace('{{ value }}', String(value))
                     .replace('{{ compared_value }}', String(this.value))
             ];
         }

--- a/Resources/public/js/constraints/LessThanOrEqual.js
+++ b/Resources/public/js/constraints/LessThanOrEqual.js
@@ -15,8 +15,8 @@ function SymfonyComponentValidatorConstraintsLessThanOrEqual() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ compared_value }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
             ];
         }
     }

--- a/Resources/public/js/constraints/NotBlank.js
+++ b/Resources/public/js/constraints/NotBlank.js
@@ -12,7 +12,7 @@ function SymfonyComponentValidatorConstraintsNotBlank() {
         var f = FpJsFormValidator;
 
         if (f.isValueEmty(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/NotEqualTo.js
+++ b/Resources/public/js/constraints/NotEqualTo.js
@@ -13,9 +13,9 @@ function SymfonyComponentValidatorConstraintsNotEqualTo() {
         if ('' !== value && this.value == value) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ compared_value }}', String(this.value))
-                    .replace('{{ compared_value_type }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
+                    .replace('{{ compared_value_type }}', FpJsBaseConstraint.formatValue(this.value))
             );
         }
 

--- a/Resources/public/js/constraints/NotEqualTo.js
+++ b/Resources/public/js/constraints/NotEqualTo.js
@@ -13,7 +13,7 @@ function SymfonyComponentValidatorConstraintsNotEqualTo() {
         if ('' !== value && this.value == value) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', String(this.value))
+                    .replace('{{ value }}', String(value))
                     .replace('{{ compared_value }}', String(this.value))
                     .replace('{{ compared_value_type }}', String(this.value))
             );

--- a/Resources/public/js/constraints/NotIdenticalTo.js
+++ b/Resources/public/js/constraints/NotIdenticalTo.js
@@ -13,9 +13,9 @@ function SymfonyComponentValidatorConstraintsNotIdenticalTo() {
         if ('' !== value && this.value === value) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ compared_value }}', String(this.value))
-                    .replace('{{ compared_value_type }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
+                    .replace('{{ compared_value_type }}', FpJsBaseConstraint.formatValue(this.value))
             );
         }
 

--- a/Resources/public/js/constraints/NotNull.js
+++ b/Resources/public/js/constraints/NotNull.js
@@ -10,7 +10,7 @@ function SymfonyComponentValidatorConstraintsNotNull() {
     this.validate = function (value) {
         var errors = [];
         if (null === value) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/Null.js
+++ b/Resources/public/js/constraints/Null.js
@@ -10,7 +10,7 @@ function SymfonyComponentValidatorConstraintsNull() {
     this.validate = function(value) {
         var errors = [];
         if (null !== value) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/Range.js
+++ b/Resources/public/js/constraints/Range.js
@@ -21,21 +21,21 @@ function SymfonyComponentValidatorConstraintsRange() {
         if (isNaN(value)) {
             errors.push(
                 this.invalidMessage
-                    .replace('{{ value }}', String(value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
             );
         }
         if (!isNaN(this.max) && value > this.max) {
             errors.push(
                 this.maxMessage
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ limit }}', this.max)
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ limit }}', FpJsBaseConstraint.formatValue(this.max))
             );
         }
         if (!isNaN(this.min) && value < this.min) {
             errors.push(
                 this.minMessage
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ limit }}', this.min)
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ limit }}', FpJsBaseConstraint.formatValue(this.min))
             );
         }
 

--- a/Resources/public/js/constraints/Regex.js
+++ b/Resources/public/js/constraints/Regex.js
@@ -14,7 +14,7 @@ function SymfonyComponentValidatorConstraintsRegex() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !this.pattern.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/Time.js
+++ b/Resources/public/js/constraints/Time.js
@@ -13,7 +13,7 @@ function SymfonyComponentValidatorConstraintsTime() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/True.js
+++ b/Resources/public/js/constraints/True.js
@@ -14,7 +14,7 @@ function SymfonyComponentValidatorConstraintsTrue() {
 
         var errors = [];
         if (true !== value) {
-            errors.push(this.message.replace('{{ value }}', value));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;

--- a/Resources/public/js/constraints/Type.js
+++ b/Resources/public/js/constraints/Type.js
@@ -56,7 +56,6 @@ function SymfonyComponentValidatorConstraintsType() {
 
             case 'scalar':
                 isValid = (/boolean|number|string/).test(typeof value);
-                value = 'Array';
                 break;
 
             case '':
@@ -76,7 +75,7 @@ function SymfonyComponentValidatorConstraintsType() {
         if (!isValid) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', value)
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
                     .replace('{{ type }}', this.type)
             );
         }

--- a/Resources/public/js/constraints/Url.js
+++ b/Resources/public/js/constraints/Url.js
@@ -14,7 +14,7 @@ function SymfonyComponentValidatorConstraintsUrl() {
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
             element.domNode.value = 'http://' + value;
-            errors.push(this.message.replace('{{ value }}', String('http://' + value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue('http://' + value)));
         }
 
         return errors;

--- a/Resources/public/js/fp_js_validator.js
+++ b/Resources/public/js/fp_js_validator.js
@@ -233,7 +233,7 @@ function FpJsCustomizeMethods() {
                 if (data['entity'] && data['entity']['constraints']) {
                     for (var i in data['entity']['constraints']) {
                         var constraint = data['entity']['constraints'][i];
-                        if (constraint instanceof FpJsFormValidatorBundleFormConstraintUniqueEntity && constraint.fields.indexOf(item.name)) {
+                        if (constraint instanceof FpJsFormValidatorBundleFormConstraintUniqueEntity && constraint.fields.indexOf(item.jsFormValidator.name) > -1) {
                             var owner = item.jsFormValidator.parent;
                             constraint.validate(null, owner);
                         }
@@ -335,6 +335,31 @@ var FpJsBaseConstraint = {
         }
 
         return realMsg;
+    },
+
+    formatValue: function (value) {
+        switch (Object.prototype.toString.call(value)) {
+            case '[object Date]':
+                return value.format('Y-m-d H:i:s');
+
+            case '[object Object]':
+                return 'object';
+
+            case '[object Array]':
+                return 'array';
+
+            case '[object String]':
+                return '"' + value + '"';
+
+            case '[object Null]':
+                return 'null';
+
+            case '[object Boolean]':
+                return value ? 'true' : 'false';
+
+            default:
+                return String(value);
+        }
     }
 };
 
@@ -999,6 +1024,7 @@ var FpJsFormValidator = new function () {
         return length;
     };
 }();
+
 //noinspection JSUnusedGlobalSymbols,JSUnusedGlobalSymbols
 /**
  * Checks if value is blank
@@ -1013,7 +1039,7 @@ function SymfonyComponentValidatorConstraintsBlank() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1081,7 +1107,10 @@ function SymfonyComponentValidatorConstraintsChoice() {
         if (this.multiple) {
             if (invalidCnt) {
                 while (invalidCnt--) {
-                    errors.push(this.multipleMessage.replace('{{ value }}', String(invalidList[invalidCnt])));
+                    errors.push(this.multipleMessage.replace(
+                        '{{ value }}',
+                        FpJsBaseConstraint.formatValue(invalidList[invalidCnt])
+                    ));
                 }
             }
             if (!isNaN(this.min) && value.length < this.min) {
@@ -1092,7 +1121,10 @@ function SymfonyComponentValidatorConstraintsChoice() {
             }
         } else if (invalidCnt) {
             while (invalidCnt--) {
-                errors.push(this.message.replace('{{ value }}', String(invalidList[invalidCnt])));
+                errors.push(this.message.replace(
+                    '{{ value }}',
+                    FpJsBaseConstraint.formatValue(invalidList[invalidCnt])
+                ));
             }
         }
 
@@ -1105,12 +1137,12 @@ function SymfonyComponentValidatorConstraintsChoice() {
 
         this.minMessage = FpJsBaseConstraint.prepareMessage(
             this.minMessage,
-            {'{{ limit }}': this.min},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.min)},
             this.min
         );
         this.maxMessage = FpJsBaseConstraint.prepareMessage(
             this.maxMessage,
-            {'{{ limit }}': this.max},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.max)},
             this.max
         );
     };
@@ -1213,17 +1245,17 @@ function SymfonyComponentValidatorConstraintsCount() {
 
         this.minMessage = FpJsBaseConstraint.prepareMessage(
             this.minMessage,
-            {'{{ limit }}': this.min},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.min)},
             this.min
         );
         this.maxMessage = FpJsBaseConstraint.prepareMessage(
             this.maxMessage,
-            {'{{ limit }}': this.max},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.max)},
             this.max
         );
         this.exactMessage = FpJsBaseConstraint.prepareMessage(
             this.exactMessage,
-            {'{{ limit }}': this.min},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.min)},
             this.min
         );
     }
@@ -1244,7 +1276,7 @@ function SymfonyComponentValidatorConstraintsDate() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1266,7 +1298,7 @@ function SymfonyComponentValidatorConstraintsDateTime() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1287,7 +1319,7 @@ function SymfonyComponentValidatorConstraintsEmail() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1311,9 +1343,9 @@ function SymfonyComponentValidatorConstraintsEqualTo() {
         if (!f.isValueEmty(value) && this.value != value) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', String(this.value))
-                    .replace('{{ compared_value }}', String(this.value))
-                    .replace('{{ compared_value_type }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
+                    .replace('{{ compared_value_type }}', FpJsBaseConstraint.formatValue(this.value))
             );
         }
 
@@ -1333,7 +1365,7 @@ function SymfonyComponentValidatorConstraintsFalse() {
     this.validate = function (value) {
         var errors = [];
         if ('' !== value && false !== value) {
-            errors.push(this.message.replace('{{ value }}', value));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1357,8 +1389,8 @@ function SymfonyComponentValidatorConstraintsGreaterThan() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(this.value))
-                    .replace('{{ compared_value }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
             ];
         }
     }
@@ -1381,8 +1413,8 @@ function SymfonyComponentValidatorConstraintsGreaterThanOrEqual() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(this.value))
-                    .replace('{{ compared_value }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
             ];
         }
     }
@@ -1403,9 +1435,9 @@ function SymfonyComponentValidatorConstraintsIdenticalTo() {
         if ('' !== value && this.value !== value) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ compared_value }}', String(this.value))
-                    .replace('{{ compared_value_type }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
+                    .replace('{{ compared_value_type }}', FpJsBaseConstraint.formatValue(this.value))
             );
         }
 
@@ -1428,7 +1460,7 @@ function SymfonyComponentValidatorConstraintsIp() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1475,17 +1507,17 @@ function SymfonyComponentValidatorConstraintsLength() {
 
         this.minMessage = FpJsBaseConstraint.prepareMessage(
             this.minMessage,
-            {'{{ limit }}': this.min},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.min)},
             this.min
         );
         this.maxMessage = FpJsBaseConstraint.prepareMessage(
             this.maxMessage,
-            {'{{ limit }}': this.max},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.max)},
             this.max
         );
         this.exactMessage = FpJsBaseConstraint.prepareMessage(
             this.exactMessage,
-            {'{{ limit }}': this.min},
+            {'{{ limit }}': FpJsBaseConstraint.formatValue(this.min)},
             this.min
         );
     }
@@ -1508,8 +1540,8 @@ function SymfonyComponentValidatorConstraintsLessThan() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(this.value))
-                    .replace('{{ compared_value }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
             ];
         }
     }
@@ -1532,8 +1564,8 @@ function SymfonyComponentValidatorConstraintsLessThanOrEqual() {
         } else {
             return [
                 this.message
-                    .replace('{{ value }}', String(this.value))
-                    .replace('{{ compared_value }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
             ];
         }
     }
@@ -1553,7 +1585,7 @@ function SymfonyComponentValidatorConstraintsNotBlank() {
         var f = FpJsFormValidator;
 
         if (f.isValueEmty(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1575,9 +1607,9 @@ function SymfonyComponentValidatorConstraintsNotEqualTo() {
         if ('' !== value && this.value == value) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', String(this.value))
-                    .replace('{{ compared_value }}', String(this.value))
-                    .replace('{{ compared_value_type }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
+                    .replace('{{ compared_value_type }}', FpJsBaseConstraint.formatValue(this.value))
             );
         }
 
@@ -1600,9 +1632,9 @@ function SymfonyComponentValidatorConstraintsNotIdenticalTo() {
         if ('' !== value && this.value === value) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ compared_value }}', String(this.value))
-                    .replace('{{ compared_value_type }}', String(this.value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ compared_value }}', FpJsBaseConstraint.formatValue(this.value))
+                    .replace('{{ compared_value_type }}', FpJsBaseConstraint.formatValue(this.value))
             );
         }
 
@@ -1622,7 +1654,7 @@ function SymfonyComponentValidatorConstraintsNotNull() {
     this.validate = function (value) {
         var errors = [];
         if (null === value) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1641,7 +1673,7 @@ function SymfonyComponentValidatorConstraintsNull() {
     this.validate = function(value) {
         var errors = [];
         if (null !== value) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1671,21 +1703,21 @@ function SymfonyComponentValidatorConstraintsRange() {
         if (isNaN(value)) {
             errors.push(
                 this.invalidMessage
-                    .replace('{{ value }}', String(value))
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
             );
         }
         if (!isNaN(this.max) && value > this.max) {
             errors.push(
                 this.maxMessage
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ limit }}', this.max)
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ limit }}', FpJsBaseConstraint.formatValue(this.max))
             );
         }
         if (!isNaN(this.min) && value < this.min) {
             errors.push(
                 this.minMessage
-                    .replace('{{ value }}', String(value))
-                    .replace('{{ limit }}', this.min)
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
+                    .replace('{{ limit }}', FpJsBaseConstraint.formatValue(this.min))
             );
         }
 
@@ -1714,7 +1746,7 @@ function SymfonyComponentValidatorConstraintsRegex() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !this.pattern.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1741,7 +1773,7 @@ function SymfonyComponentValidatorConstraintsTime() {
         var f = FpJsFormValidator;
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
-            errors.push(this.message.replace('{{ value }}', String(value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1764,7 +1796,7 @@ function SymfonyComponentValidatorConstraintsTrue() {
 
         var errors = [];
         if (true !== value) {
-            errors.push(this.message.replace('{{ value }}', value));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
         return errors;
@@ -1830,7 +1862,6 @@ function SymfonyComponentValidatorConstraintsType() {
 
             case 'scalar':
                 isValid = (/boolean|number|string/).test(typeof value);
-                value = 'Array';
                 break;
 
             case '':
@@ -1850,7 +1881,7 @@ function SymfonyComponentValidatorConstraintsType() {
         if (!isValid) {
             errors.push(
                 this.message
-                    .replace('{{ value }}', value)
+                    .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
                     .replace('{{ type }}', this.type)
             );
         }
@@ -1977,7 +2008,7 @@ function SymfonyComponentValidatorConstraintsUrl() {
 
         if (!f.isValueEmty(value) && !regexp.test(value)) {
             element.domNode.value = 'http://' + value;
-            errors.push(this.message.replace('{{ value }}', String('http://' + value)));
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue('http://' + value)));
         }
 
         return errors;

--- a/Tests/app/Resources/config.php
+++ b/Tests/app/Resources/config.php
@@ -61,7 +61,13 @@ $container->loadFromExtension('doctrine', array(
     'orm' => array(
         'auto_mapping' => true
     ),
-    'dbal' => array()
+    'dbal' => array(
+        'connections' => array(
+            'default' => array(
+                'driver'   => 'pdo_sqlite',
+            )
+        )
+    )
 ));
 $container->loadFromExtension(
     'mink',

--- a/Tests/app/switch_sf_version.sh
+++ b/Tests/app/switch_sf_version.sh
@@ -15,7 +15,7 @@ move() {
     echo "$1 enabled!"
 }
 
-if [[ '~2.3.0' == "$1" ]]; then
+if [[ '~2.3.0,>=2.3.19' == "$1" ]]; then
     NATIVE="$DIR/Tests/TestBundles/DefaultTestBundle/Entity/CustomizationEntity.php"
     SF23="$DIR/Tests/TestBundles/DefaultTestBundle/Entity/CustomizationEntity_sf_2_3.php"
     move "$SF23" "$NATIVE"

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/form": ">=2.3",
-        "symfony/validator": ">=2.3"
+        "symfony/validator": "~2.3.0,>=2.3.19||~2.4.0,>=2.4.9||~2.5.0,>=2.5.3,<=2.5.4"
     },
 
     "require-dev": {
         "doctrine/orm": ">=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
-        "symfony/symfony": ">=2.3",
+        "symfony/symfony": "~2.3.0,>=2.3.19||~2.4.0,>=2.4.9||~2.5.0,>=2.5.3,<=2.5.4",
         "symfony/assetic-bundle": ">=2.3",
         "phpunit/phpunit": "3.7.*",
         "behat/mink-bundle": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "phpunit/phpunit": "3.7.*",
         "behat/mink-bundle": "dev-master",
         "behat/mink-selenium2-driver": "1.1.0",
-        "satooshi/php-coveralls": "dev-master"
+        "satooshi/php-coveralls": "dev-master",
+        "se/selenium-server-standalone": "2.45.0"
     },
 
     "suggest": {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -44,7 +44,7 @@ fi
 #------------------- Run Selenium -------------------#
 #----------------------------------------------------#
 if [ ! -f selenium.jar ]; then
-    curl http://selenium.googlecode.com/files/selenium-server-standalone-2.33.0.jar > selenium.jar
+    curl http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar > selenium.jar
 fi
 java -jar selenium.jar > selenium.log &
 sleep 4


### PR DESCRIPTION
Be aware that it makes the bundle not compatible with Symfony versions pre v2.3.19, v2.4.9 and v2.5.3.
Also, the last supported version is 2.5.4, because in 2.5.5 they changed behaviour of multiple Choice validator which no longer prints all the violations but only the first one.