### PR TITLE
Fixed validation_groups when option is a Closure

### DIFF
--- a/Factory/JsFormValidatorFactory.php
+++ b/Factory/JsFormValidatorFactory.php
@@ -428,8 +428,8 @@ class JsFormValidatorFactory
             // If groups is an array - return groups as is
             $result = $groups;
         } elseif ($groups instanceof \Closure) {
-            // If groups is a Closure - return the form class name to look for javascript
-            $result = $this->getElementId($form);
+            // If groups is a Closure - return the closure response
+            $result = $groups($form);
         }
 
         return $result;

--- a/Tests/Factory/JsFormValidatorFactoryTest.php
+++ b/Tests/Factory/JsFormValidatorFactoryTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Fp\JsFormValidatorBundle\Tests\Factory;
+
+use Fp\JsFormValidatorBundle\Factory\JsFormValidatorFactory;
+
+/**
+ * Class JsFormValidatorFactoryTest
+ */
+class JsFormValidatorFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var JsFormValidatorFactory
+     */
+    protected $factory;
+
+    /**
+     * Sets up a new test factory instance.
+     */
+    public function setUp()
+    {
+        $this->factory = $this->getMockBuilder('Fp\JsFormValidatorBundle\Factory\JsFormValidatorFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * Tears down test class properties.
+     */
+    public function tearDown()
+    {
+        $this->factory = null;
+    }
+
+    /**
+     * Tests the getValidationGroups() method when returning an empty array.
+     */
+    public function testGetValidationGroupsWhenEmpty()
+    {
+        // Given
+        $formConfig = $this->getMock('Symfony\Component\Form\FormConfigInterface');
+        $formConfig
+            ->expects($this->once())
+            ->method('getOption')
+            ->with($this->equalTo('validation_groups'))
+            ->will($this->returnValue(null));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $form->expects($this->once())->method('getConfig')->will($this->returnValue($formConfig));
+
+        $factory = new \ReflectionMethod($this->factory, 'getValidationGroups');
+        $factory->setAccessible(true);
+
+        // When
+        $result = $factory->invoke($this->factory, $form);
+
+        // Then
+        $this->assertEquals(array('Default'), $result, 'Should return Default as validation_groups');
+    }
+
+    /**
+     * Tests the getValidationGroups() method when using a simple array.
+     */
+    public function testGetValidationGroupsWhenArray()
+    {
+        // Given
+        $formConfig = $this->getMock('Symfony\Component\Form\FormConfigInterface');
+        $formConfig
+            ->expects($this->once())
+            ->method('getOption')
+            ->with($this->equalTo('validation_groups'))
+            ->will($this->returnValue(array('test1', 'test2')));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $form->expects($this->once())->method('getConfig')->will($this->returnValue($formConfig));
+
+        $factory = new \ReflectionMethod($this->factory, 'getValidationGroups');
+        $factory->setAccessible(true);
+
+        // When
+        $result = $factory->invoke($this->factory, $form);
+
+        // Then
+        $this->assertEquals(array('test1', 'test2'), $result, 'Should return the validation_groups array');
+    }
+
+    /**
+     * Tests the getValidationGroups() method when using a Closure.
+     */
+    public function testGetValidationGroupsWhenClosure()
+    {
+        // Given
+        $formConfig = $this->getMock('Symfony\Component\Form\FormConfigInterface');
+        $formConfig
+            ->expects($this->once())
+            ->method('getOption')
+            ->with($this->equalTo('validation_groups'))
+            ->will($this->returnValue(function () { return array('person'); }));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $form->expects($this->once())->method('getConfig')->will($this->returnValue($formConfig));
+
+        $factory = new \ReflectionMethod($this->factory, 'getValidationGroups');
+        $factory->setAccessible(true);
+
+        // When
+        $result = $factory->invoke($this->factory, $form);
+
+        // Then
+        $this->assertEquals(array('person'), $result, 'Should return the closure response as validation_groups');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "phpunit/phpunit": "3.7.*",
         "behat/mink-bundle": "dev-master",
         "behat/mink-selenium2-driver": "1.1.0",
-        "satooshi/php-coveralls": "dev-master",
+        "satooshi/php-coveralls": "~1.0",
         "se/selenium-server-standalone": "2.45.0"
     },
 


### PR DESCRIPTION
Hi,

I'm having an issue using this bundle on my project when having a `validation_groups` option which is a Closure.

I have a `companyName` property on my data class which can be null when using `person` validation group and cannot be blank when we are using the `company` validation group following:

```php
    /**
     * @var string
     * @Type("string")
     * @Symfony\Component\Validator\Constraints\NotNull(groups={"company"})
     * @Symfony\Component\Validator\Constraints\Null(groups={"person"})
     */
    protected $companyName;
```

Here is the closure I use to define the `validation_groups` option in my form type:

```php
    /**
     * {@inheritdoc}
     */
    public function setDefaultOptions(OptionsResolverInterface $resolver)
    {
        $resolver->setDefaults(array(
            'validation_groups' => function (FormInterface $form) {
                return $form->getData()->isCompany() ? array('company') : array('person');
            },
        ));
```

Here is the output with the current code:

```js
[
    'Symfony\\Component\\Validator\\Constraints\\NotNull':[
        {
            'message':'PinpadFullUserAccountInput.companyName.Null.message',
            'groups':[
                'Default',
                'PinpadFullUserAccountInput',
                'FullUserAccountInput'
            ]
        },
    'Symfony\\Component\\Validator\\Constraints\\Null':[
        {
            'message':'PinpadFullUserAccountInput.companyName.Null.message',
            'groups':[
                'Default',
                'PinpadFullUserAccountInput',
                'FullUserAccountInput'
            ]
        }
]
```

My form does not validate with the current code as it does not know the validation groups as it retrieves the class names instead.

Using my fix, I got a correct output and my form now validates:

```js
[
    'Symfony\\Component\\Validator\\Constraints\\NotNull':[
        {
            'message':'PinpadFullUserAccountInput.companyName.NotNull.message',
            'groups':[
                'company'
            ]
        },
    'Symfony\\Component\\Validator\\Constraints\\Null':[
        {
            'message':'PinpadFullUserAccountInput.companyName.Null.message',
            'groups':[
                'person'
            ]
        }
]
```

Note: I've also fixed the `satooshi/php-coveralls` dependency to retrieve the latest 1.0.x compatible version as 2.0.x will be available for PHP >= 5.5 only and it breaks the the composer installation (using --dev) actually.

Thank you for your quick answer.