### PR TITLE
PHP7 & Symfony3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
-php: [5.3,5.4,5.5,5.6]
+php: [5.5,5.6,7.0]
 
 env:
-  - SF_VERSION='>=2.5.5,<2.6.0'
-  - SF_VERSION='~2.6.0'
-  - SF_VERSION='~2.7.0'
+  - SF_VERSION='~3.0.0'
 
 before_script:
   - export WEB_FIXTURES_HOST=http://localhost/index.php
@@ -30,6 +28,7 @@ before_script:
   - sudo apt-get update > /dev/null
   - sudo apt-get install -y --force-yes apache2 libapache2-mod-fastcgi > /dev/null
   # enable php-fpm
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/www.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/www.conf; fi
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - sudo a2enmod rewrite actions fastcgi alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/Form/Extension/FormExtension.php
+++ b/Form/Extension/FormExtension.php
@@ -4,6 +4,7 @@ namespace Fp\JsFormValidatorBundle\Form\Extension;
 use Fp\JsFormValidatorBundle\Factory\JsFormValidatorFactory;
 use Fp\JsFormValidatorBundle\Form\Subscriber\SubscriberToQueue;
 use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -37,7 +38,7 @@ class FormExtension extends AbstractTypeExtension
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
@@ -51,6 +52,6 @@ class FormExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return 'form';
+        return FormType::class;
     }
 }

--- a/Model/JsFormElement.php
+++ b/Model/JsFormElement.php
@@ -34,11 +34,6 @@ class JsFormElement extends JsModelAbstract
     /**
      * @var bool
      */
-    public $cascade = false;
-
-    /**
-     * @var bool
-     */
     public $bubbling = false;
 
     /**

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 [![Build Status](https://travis-ci.org/formapro/JsFormValidatorBundle.svg?branch=master)](https://travis-ci.org/formapro/JsFormValidatorBundle)
 [![Total Downloads](https://poser.pugx.org/fp/jsformvalidator-bundle/downloads.png)](https://packagist.org/packages/fp/jsformvalidator-bundle)
 
-This module enables validation of the Symfony 2.5.5+ forms on the JavaScript side.
+This module enables validation of the 3.0+ forms on the JavaScript side.
 It converts form type constraints into JavaScript validation rules.
 
-If you have Symfony 2.5.4* or less* - you need to use [Version 1.2.*](https://github.com/formapro/JsFormValidatorBundle/tree/1.2)
-
-* More details here: [Symfony2](https://github.com/symfony/symfony/commit/97243bcd024bbfa458d66a4263a50ee7f16bbe74), [PR #83](https://github.com/formapro/JsFormValidatorBundle/pull/83)
-
+If you have Symfony 2.8.* or 2.7.* - you need to use [Version 1.3.*](https://github.com/formapro/JsFormValidatorBundle/tree/1.3)
+If you have Symfony 2.6.* or less - you need to use [Version 1.2.*](https://github.com/formapro/JsFormValidatorBundle/tree/1.2)
 
 ## 1 Installation<a name="p_1"></a>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,7 +18,7 @@
 
         <service id="fp_js_form_validator.extension" class="%fp_js_form_validator.extension.class%">
             <argument type="service" id="fp_js_form_validator.factory" />
-            <tag name="form.type_extension" alias="form" />
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
         </service>
 
         <service id="fp_js_form_validator.factory" class="%fp_js_form_validator.factory.class%">

--- a/Resources/public/js/constraints/Callback.js
+++ b/Resources/public/js/constraints/Callback.js
@@ -11,7 +11,7 @@ function SymfonyComponentValidatorConstraintsCallback () {
         if (!this.callback) {
             this.callback = [];
         }
-        if (!this.methods) {
+        if (!this.methods.length) {
             this.methods = [this.callback];
         }
 

--- a/Resources/public/js/constraints/Choice.js
+++ b/Resources/public/js/constraints/Choice.js
@@ -28,12 +28,10 @@ function SymfonyComponentValidatorConstraintsChoice() {
 
         if (this.multiple) {
             if (invalidCnt) {
-                while (invalidCnt--) {
-                    errors.push(this.multipleMessage.replace(
-                        '{{ value }}',
-                        FpJsBaseConstraint.formatValue(invalidList[invalidCnt])
-                    ));
-                }
+                errors.push(this.multipleMessage.replace(
+                    '{{ value }}',
+                    FpJsBaseConstraint.formatValue(invalidList[0])
+                ));
             }
             if (!isNaN(this.min) && value.length < this.min) {
                 errors.push(this.minMessage);

--- a/Resources/public/js/constraints/False.js
+++ b/Resources/public/js/constraints/False.js
@@ -4,15 +4,4 @@
  * @constructor
  * @author dev.ymalcev@gmail.com
  */
-function SymfonyComponentValidatorConstraintsFalse() {
-    this.message = '';
-
-    this.validate = function (value) {
-        var errors = [];
-        if ('' !== value && false !== value) {
-            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
-        }
-
-        return errors;
-    }
-}
+var SymfonyComponentValidatorConstraintsFalse = SymfonyComponentValidatorConstraintsIsFalse;

--- a/Resources/public/js/constraints/IsFalse.js
+++ b/Resources/public/js/constraints/IsFalse.js
@@ -1,0 +1,18 @@
+//noinspection JSUnusedGlobalSymbols
+/**
+ * Checks if value is (bool) false
+ * @constructor
+ * @author dev.ymalcev@gmail.com
+ */
+function SymfonyComponentValidatorConstraintsIsFalse() {
+    this.message = '';
+
+    this.validate = function (value) {
+        var errors = [];
+        if ('' !== value && false !== value) {
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
+        }
+
+        return errors;
+    }
+}

--- a/Resources/public/js/constraints/IsNull.js
+++ b/Resources/public/js/constraints/IsNull.js
@@ -1,0 +1,18 @@
+//noinspection JSUnusedGlobalSymbols
+/**
+ * Checks if value is null
+ * @constructor
+ * @author dev.ymalcev@gmail.com
+ */
+function SymfonyComponentValidatorConstraintsIsNull() {
+    this.message = '';
+
+    this.validate = function(value) {
+        var errors = [];
+        if (null !== value) {
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
+        }
+
+        return errors;
+    }
+}

--- a/Resources/public/js/constraints/IsTrue.js
+++ b/Resources/public/js/constraints/IsTrue.js
@@ -1,0 +1,23 @@
+//noinspection JSUnusedGlobalSymbols
+/**
+ * Checks if value is (bool) true
+ * @constructor
+ * @author dev.ymalcev@gmail.com
+ */
+function SymfonyComponentValidatorConstraintsIsTrue() {
+    this.message = '';
+
+    this.validate = function(value) {
+        if ('' === value) {
+            return [];
+        }
+
+        var errors = [];
+        if (true !== value) {
+            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
+        }
+
+        return errors;
+    }
+}
+

--- a/Resources/public/js/constraints/Null.js
+++ b/Resources/public/js/constraints/Null.js
@@ -4,15 +4,4 @@
  * @constructor
  * @author dev.ymalcev@gmail.com
  */
-function SymfonyComponentValidatorConstraintsNull() {
-    this.message = '';
-
-    this.validate = function(value) {
-        var errors = [];
-        if (null !== value) {
-            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
-        }
-
-        return errors;
-    }
-}
+var SymfonyComponentValidatorConstraintsNull = SymfonyComponentValidatorConstraintsIsNull;

--- a/Resources/public/js/constraints/True.js
+++ b/Resources/public/js/constraints/True.js
@@ -4,20 +4,4 @@
  * @constructor
  * @author dev.ymalcev@gmail.com
  */
-function SymfonyComponentValidatorConstraintsTrue() {
-    this.message = '';
-
-    this.validate = function(value) {
-        if ('' === value) {
-            return [];
-        }
-
-        var errors = [];
-        if (true !== value) {
-            errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
-        }
-
-        return errors;
-    }
-}
-
+var SymfonyComponentValidatorConstraintsTrue = SymfonyComponentValidatorConstraintsTrue;

--- a/Resources/public/js/constraints/Valid.js
+++ b/Resources/public/js/constraints/Valid.js
@@ -1,0 +1,9 @@
+//noinspection JSUnusedGlobalSymbols
+/**
+ * @constructor
+ */
+function SymfonyComponentValidatorConstraintsValid() {
+    this.validate = function (value, element) {
+        return [];
+    };
+}

--- a/Tests/BaseMinkTestCase.php
+++ b/Tests/BaseMinkTestCase.php
@@ -123,8 +123,8 @@ class BaseMinkTestCase extends MinkTestCase
             static::$uploader = \RemoteImageUploader\Factory::create('Imageshack', array(
 //                'cacher' => $cacher,
                 'api_key' => '849MPVZ0ccccf4d199886724532ccaad3d8799cf',
-                'username' => 'JsFormValidatorBundle@66ton99.org.ua',
-                'password' => 'b5SSquF7kmp1'
+                'username' => 'JsFormValidatorBundle@66ton99.org.ua6ton99.org.ua',
+                'pb5SSquF7kmp1d' => 'b5SSquF7kmp1'
             ));
             static::$uploader->login();
         }
@@ -139,12 +139,9 @@ class BaseMinkTestCase extends MinkTestCase
         }
 
         try {
-            $name = date('Y-m-d_H:i:s') . '.png';
-            file_put_contents(
-                '/tmp/' . $name,
-                $this->session->getScreenshot()
-            );
-            $imageUrl = $this->getUploader()->upload('/tmp/' . $name);
+            $path = sprintf('%s/%s.png', sys_get_temp_dir(), date('Y-m-d_H-i-s'));
+            file_put_contents($path, $this->session->getScreenshot());
+            $imageUrl = $this->getUploader()->upload($path);
         } catch (\Exception $e) {
             $imageUrl = $e->getMessage();
         }

--- a/Tests/Fixtures/Entity.php
+++ b/Tests/Fixtures/Entity.php
@@ -74,7 +74,7 @@ class Entity
 
     /**
      * @return bool
-     * @Assert\True(message = "wrong_name")
+     * @Assert\IsTrue(message = "wrong_name")
      */
     public function isNameLegal()
     {

--- a/Tests/Fixtures/FormGroupsArray.php
+++ b/Tests/Fixtures/FormGroupsArray.php
@@ -3,6 +3,7 @@
 namespace Fp\JsFormValidatorBundle\Tests\Fixtures;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -19,11 +20,11 @@ class FormGroupsArray extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'text');
+        $builder->add('name', TextType::class);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
@@ -31,13 +32,5 @@ class FormGroupsArray extends AbstractType
             'data_class' => 'Fp\JsFormValidatorBundle\Tests\Fixtures\Entity',
             'validation_groups' => array('array'),
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'fp_jsformvalidatorbundle_tests_fixtures_formgroupsarray';
     }
 }

--- a/Tests/Fixtures/FormGroupsClosure.php
+++ b/Tests/Fixtures/FormGroupsClosure.php
@@ -3,6 +3,7 @@
 namespace Fp\JsFormValidatorBundle\Tests\Fixtures;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -19,11 +20,11 @@ class FormGroupsClosure extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'text');
+        $builder->add('name', TextType::class);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      *
      * @return void
      */
@@ -35,13 +36,5 @@ class FormGroupsClosure extends AbstractType
                 return array('test');
             }
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'fp_jsformvalidatorbundle_tests_fixtures_formgroupsclosure';
     }
 }

--- a/Tests/Fixtures/SimpleForms/FormOne.php
+++ b/Tests/Fixtures/SimpleForms/FormOne.php
@@ -2,22 +2,13 @@
 namespace Fp\JsFormValidatorBundle\Tests\Fixtures\SimpleForms;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class FormOne extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'text');
-    }
-
-    /**
-     * Returns the name of this type.
-     *
-     * @return string The name of this type
-     */
-    public function getName()
-    {
-        return 'form_one';
+        $builder->add('name', TextType::class);
     }
 }

--- a/Tests/Fixtures/SimpleForms/FormTwo.php
+++ b/Tests/Fixtures/SimpleForms/FormTwo.php
@@ -2,22 +2,13 @@
 namespace Fp\JsFormValidatorBundle\Tests\Fixtures\SimpleForms;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class FormTwo extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'text');
-    }
-
-    /**
-     * Returns the name of this type.
-     *
-     * @return string The name of this type
-     */
-    public function getName()
-    {
-        return 'form_two';
+        $builder->add('name', TextType::class);
     }
 }

--- a/Tests/Fixtures/TestForm.php
+++ b/Tests/Fixtures/TestForm.php
@@ -3,6 +3,9 @@
 namespace Fp\JsFormValidatorBundle\Tests\Fixtures;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -20,13 +23,13 @@ class TestForm extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', 'text')
-            ->add('file', 'file')
-            ->add('save', 'submit');
+            ->add('name', TextType::class)
+            ->add('file', FileType::class)
+            ->add('save', SubmitType::class);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
@@ -34,13 +37,5 @@ class TestForm extends AbstractType
             'data_class' => 'Fp\JsFormValidatorBundle\Tests\Fixtures\Entity',
             // do not specify groups here
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'fp_jsformvalidatorbundle_tests_fixtures_formgroupsarray';
     }
 }

--- a/Tests/Functional/MainFunctionalTest.php
+++ b/Tests/Functional/MainFunctionalTest.php
@@ -90,9 +90,9 @@ class MainFunctionalTest extends BaseMinkTestCase
         $this->assertCount(5, $fpErrors);
         /** @var DocumentElement $page */
         $page = $this->session->getPage();
-        $page->findField('form_name')->setValue('a');
-        $page->findField('form_email')->setValue('a');
-        $page->findField('form_title')->setValue('a');
+        $page->findField('unique_name')->setValue('a');
+        $page->findField('unique_email')->setValue('a');
+        $page->findField('unique_title')->setValue('a');
         $page->findLink('a_submit')->click();
         $this->session->wait(5000, '$("#extra_msg").text() == "unique_entity_valid"');
         $extraMsg = $this->session->getPage()->find('css', '#extra_msg')->getText();
@@ -253,7 +253,7 @@ class MainFunctionalTest extends BaseMinkTestCase
             'validate_callback_email_custom'
         );
 
-        $jqErrors = $this->getAllErrorsOnPage('customization/jq/1', null, 'custom_form_name_submit');
+        $jqErrors = $this->getAllErrorsOnPage('customization/jq/1', null, 'customization_submit');
         $this->assertErrorsEqual($expected, $jqErrors, 'All the jQuery customizations were applied');
 
         /** @var DocumentElement $page */
@@ -261,12 +261,12 @@ class MainFunctionalTest extends BaseMinkTestCase
         $onValidateMsg = $page->find('css', '#on_validate_msg_container')->getText();
         $this->assertErrorsEqual($expected, explode(', ', $onValidateMsg));
 
-        $field = $page->findField('custom_form_name_showErrors');
+        $field = $page->findField('customization_showErrors');
         $field->setValue('asdf');
         $field->blur();
         $this->assertNull($page->find('css', '.form-error-custom-form-name-showErrors'));
 
-        $jsErrors = $this->getAllErrorsOnPage('customization/js/1', null, 'custom_form_name_submit');
+        $jsErrors = $this->getAllErrorsOnPage('customization/js/1', null, 'customization_submit');
         $this->assertErrorsEqual($expected, $jsErrors, 'All the Javascript customizations were applied');
 
         /** @var DocumentElement $page */
@@ -286,9 +286,9 @@ class MainFunctionalTest extends BaseMinkTestCase
 
     public function testCollection()
     {
-        $errors = $this->getAllErrorsOnPage('collection/-/-', null, 'form_task_submit');
+        $errors = $this->getAllErrorsOnPage('collection/-/-', null, 'task_submit');
         $page = $this->session->getPage();
-        $submit = $page->findButton('form_task_submit');
+        $submit = $page->findButton('task_submit');
         $getErrors = function () use ($page) {
             $errors = array();
             /** @var \Behat\Mink\Element\NodeElement $item */
@@ -323,16 +323,16 @@ class MainFunctionalTest extends BaseMinkTestCase
 
         $this->assertEquals($getExpected(4, 3, 0), array_count_values($getErrors()));
 
-        $this->find('#del_form_task_tags_2')->click();
-        $this->find('#del_form_task_comments_1')->click();
+        $this->find('#del_task_tags_2')->click();
+        $this->find('#del_task_comments_1')->click();
         $submit->click();
         $this->assertEquals($getExpected(3, 2, 0), array_count_values($getErrors()));
 
-        $page->findField('form_task_tags_0_title')->setValue('asdf');
-        $page->findField('form_task_tags_1_title')->setValue('asdf');
-        $page->findField('form_task_tags_3_title')->setValue('asdf');
-        $page->findField('form_task_comments_0_content')->setValue('asdf');
-        $page->findField('form_task_comments_2_content')->setValue('asdf');
+        $page->findField('task_tags_0_title')->setValue('asdf');
+        $page->findField('task_tags_1_title')->setValue('asdf');
+        $page->findField('task_tags_3_title')->setValue('asdf');
+        $page->findField('task_comments_0_content')->setValue('asdf');
+        $page->findField('task_comments_2_content')->setValue('asdf');
         $submit->click();
         $extraMsgEl = $this->session->getPage()->find('css', '#extra_msg');
         $this->assertNotNull($extraMsgEl);
@@ -341,22 +341,22 @@ class MainFunctionalTest extends BaseMinkTestCase
 
     public function testEmptyChoice()
     {
-        $sfErrors = $this->getAllErrorsOnPage('empty_choice/1/0', null, 'form_choice_submit');
+        $sfErrors = $this->getAllErrorsOnPage('empty_choice/1/0', null, 'empty_choice_submit');
         $this->assertTrue($this->wasPostRequest());
-        $fpErrors = $this->getAllErrorsOnPage('empty_choice/1/1', null, 'form_choice_submit');
+        $fpErrors = $this->getAllErrorsOnPage('empty_choice/1/1', null, 'empty_choice_submit');
         $this->assertTrue($this->wasPostRequest());
         $this->assertErrorsEqual($sfErrors, $fpErrors, 'Choice fields are valid.');
 
-        $sfErrors = $this->getAllErrorsOnPage('empty_choice/0/0', null, 'form_choice_submit');
+        $sfErrors = $this->getAllErrorsOnPage('empty_choice/0/0', null, 'empty_choice_submit');
         $this->assertTrue($this->wasPostRequest());
-        $fpErrors = $this->getAllErrorsOnPage('empty_choice/0/1', null, 'form_choice_submit');
+        $fpErrors = $this->getAllErrorsOnPage('empty_choice/0/1', null, 'empty_choice_submit');
         $this->assertFalse($this->wasPostRequest());
         $this->assertErrorsEqual($sfErrors, $fpErrors, 'Choice fields have all the errors.');
     }
 
     public function testPasswordField()
     {
-        $btnId = 'form_password_field_submit';
+        $btnId = 'password_field_submit';
         // Check the valid values
         $sfErrors = $this->getAllErrorsOnPage('password_field/1/0', null, $btnId);
         $fpErrors = $this->getAllErrorsOnPage('password_field/1/1', null, $btnId);
@@ -365,11 +365,11 @@ class MainFunctionalTest extends BaseMinkTestCase
         $session = $this->session;
         $changeAndGetErrors = function ($first, $second) use ($session) {
             $page = $session->getPage();
-            $submit = $page->findButton('form_password_field_submit');
+            $submit = $page->findButton('password_field_submit');
 
             // Check the Length constraint
-            $page->findField('form_password_field_password_first')->setValue($first);
-            $page->findField('form_password_field_password_second')->setValue($second);
+            $page->findField('password_field_password_first')->setValue($first);
+            $page->findField('password_field_password_second')->setValue($second);
             $submit->click();
             $errors = array();
             /** @var \Behat\Mink\Element\NodeElement $item */

--- a/Tests/TestBundles/DefaultTestBundle/Controller/BaseTestController.php
+++ b/Tests/TestBundles/DefaultTestBundle/Controller/BaseTestController.php
@@ -8,6 +8,7 @@ use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form\TestSubFor
 use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form\TestFormType;
 use Symfony\Component\Form\Form;
 use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\TestEntity;
+use Symfony\Component\Validator\Constraints\Valid;
 
 class BaseTestController extends  Controller {
     /**
@@ -32,7 +33,7 @@ class BaseTestController extends  Controller {
     {
         return $this
             ->createForm(
-                new TestFormType(),
+                TestFormType::class,
                 new TestEntity(),
                 array(
                     'validation_groups' => $groups,
@@ -45,30 +46,32 @@ class BaseTestController extends  Controller {
     {
         return $this
             ->createForm(
-                new TestFormType(),
+                TestFormType::class,
                 new TestEntity(),
                 array(
                     'validation_groups'  => array('groups_array'),
-                    'cascade_validation' => $cascade,
                     'js_validation'      => $js,
                 )
             )
             ->add(
                 'email',
-                new TestSubFormType(),
+                TestSubFormType::class,
                 array(
                     'error_bubbling'    => $bubbling,
-                    'constraints'       => array(
-                        new Type(array(
-                            'type'    => 'integer',
-                            'message' => 'child_groups_array_message',
-                            'groups'  => array('groups_array'),
-                        )),
-                        new Type(array(
-                            'type'    => 'integer',
-                            'message' => 'child_groups_child_message',
-                            'groups'  => array('groups_child'),
-                        ))
+                    'constraints'       => array_merge(
+                        $cascade ? array(new Valid()) : array(),
+                        array(
+                            new Type(array(
+                                'type'    => 'integer',
+                                'message' => 'child_groups_array_message',
+                                'groups'  => array('groups_array'),
+                            )),
+                            new Type(array(
+                                'type'    => 'integer',
+                                'message' => 'child_groups_child_message',
+                                'groups'  => array('groups_child'),
+                            ))
+                        )
                     ),
                     'validation_groups' => $childGroups
                 )

--- a/Tests/TestBundles/DefaultTestBundle/Controller/FunctionalTestsController.php
+++ b/Tests/TestBundles/DefaultTestBundle/Controller/FunctionalTestsController.php
@@ -14,21 +14,31 @@ use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\UniqueEn
 use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form\AsyncLoadType;
 use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form\BasicConstraintsEntityType;
 use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form\CustomizationType;
-use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form\EmtyChoiceType;
+use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form\EmptyChoiceType;
 use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form\PasswordFieldType;
 use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form\TaskType;
 use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form\UniqueType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\RadioType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\Date;
 use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\EqualTo;
-use Symfony\Component\Validator\Constraints\False;
 use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\IdenticalTo;
 use Symfony\Component\Validator\Constraints\Ip;
+use Symfony\Component\Validator\Constraints\IsFalse;
+use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\LessThan;
 use Symfony\Component\Validator\Constraints\LessThanOrEqual;
@@ -37,7 +47,6 @@ use Symfony\Component\Validator\Constraints\NotEqualTo;
 use Symfony\Component\Validator\Constraints\NotIdenticalTo;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Time;
-use Symfony\Component\Validator\Constraints\True;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Constraints\Url;
 
@@ -103,7 +112,7 @@ class FunctionalTestsController extends BaseTestController
 
         $form = $this
             ->createFormBuilder(null, array('js_validation' => (bool)$js))
-            ->add('name', 'text', $constraint('blank.translation'))
+            ->add('name', TextType::class, $constraint('blank.translation'))
             ->getForm();
 
         $form->handleRequest($request);
@@ -184,7 +193,7 @@ class FunctionalTestsController extends BaseTestController
             $entity->setTitle('test');
         }
 
-        $form = $this->createForm(new UniqueType(), $entity, array('js_validation' => (bool)$js));
+        $form = $this->createForm(UniqueType::class, $entity, array('js_validation' => (bool)$js));
         $form->handleRequest($request);
 
         return $this->render(
@@ -239,7 +248,7 @@ class FunctionalTestsController extends BaseTestController
         $entity->populate($data);
         $entity->isValid = (bool)$isValid;
         $form            = $this->createForm(
-            new BasicConstraintsEntityType(),
+            BasicConstraintsEntityType::class,
             $entity,
             array('js_validation' => (bool)$js)
         );
@@ -285,18 +294,18 @@ class FunctionalTestsController extends BaseTestController
                 ),
                 array('js_validation' => (bool)$js)
             )
-            ->add('date', 'date', array('constraints' => array(new Date())))
-            ->add('time', 'time', array('constraints' => array(new Time())))
-            ->add('datetime', 'datetime', array('constraints' => array(new DateTime())))
+            ->add('date', DateType::class, array('constraints' => array(new Date())))
+            ->add('time', TimeType::class, array('constraints' => array(new Time())))
+            ->add('datetime', DateTimeType::class, array('constraints' => array(new DateTime())))
             ->add(
                 'checkbox',
-                'checkbox',
+                CheckboxType::class,
                 array(
                     'constraints' => array(
-                        new True(array(
+                        new IsTrue(array(
                             'message' => 'checkbox_false'
                         )),
-                        new False(array(
+                        new IsFalse(array(
                             'message' => 'checkbox_true'
                         ))
                     )
@@ -304,13 +313,13 @@ class FunctionalTestsController extends BaseTestController
             )
             ->add(
                 'radio',
-                'radio',
+                RadioType::class,
                 array(
                     'constraints' => array(
-                        new True(array(
+                        new IsTrue(array(
                             'message' => 'radio_false'
                         )),
-                        new False(array(
+                        new IsFalse(array(
                             'message' => 'radio_true'
                         ))
                     )
@@ -318,7 +327,7 @@ class FunctionalTestsController extends BaseTestController
             )
             ->add(
                 'ChoicesToValues',
-                'choice',
+                ChoiceType::class,
                 array(
                     'multiple'    => true,
                     'choices'     => $choices,
@@ -336,7 +345,7 @@ class FunctionalTestsController extends BaseTestController
             )
             ->add(
                 'ChoiceToValue',
-                'choice',
+                ChoiceType::class,
                 array(
                     'multiple'    => false,
                     'choices'     => $choices,
@@ -353,7 +362,7 @@ class FunctionalTestsController extends BaseTestController
             )
             ->add(
                 'ChoicesToBooleanArray',
-                'choice',
+                ChoiceType::class,
                 array(
                     'expanded'    => true,
                     'multiple'    => true,
@@ -371,7 +380,7 @@ class FunctionalTestsController extends BaseTestController
             )
             ->add(
                 'ChoiceToBooleanArray',
-                'choice',
+                ChoiceType::class,
                 array(
                     'expanded'    => true,
                     'multiple'    => false,
@@ -389,9 +398,9 @@ class FunctionalTestsController extends BaseTestController
             )
             ->add(
                 'repeated',
-                'repeated',
+                RepeatedType::class,
                 array(
-                    'type'            => 'text',
+                    'type'            => TextType::class,
                     'invalid_message' => 'not_equal',
                     'first_options'   => array('label' => 'Field'),
                     'second_options'  => array('label' => 'Repeat Field', 'data' => $isValid ? 'asdf' : 'zxcv'),
@@ -429,8 +438,8 @@ class FunctionalTestsController extends BaseTestController
 
         $form = $this
             ->createFormBuilder(null, array('js_validation' => (bool)$js))
-            ->add('name', 'text', $constraint('name_value'))
-            ->add('email', 'text', $constraint('{{ value }}'))
+            ->add('name', TextType::class, $constraint('name_value'))
+            ->add('email', TextType::class, $constraint('{{ value }}'))
             ->getForm();
 
         $form->handleRequest($request);
@@ -464,12 +473,12 @@ class FunctionalTestsController extends BaseTestController
         $form    = $builder
             ->add(
                 'name',
-                'text',
+                TextType::class,
                 array(
                     'constraints' => array(
                         new Email(array('message' => 'wrong_email')),
                         new EqualTo(array('value' => 'asdf', 'message' => 'wrong_equal_to')),
-                        new False(array('message' => 'wrong_false')),
+                        new IsFalse(array('message' => 'wrong_false')),
                         new GreaterThan(array('value' => 5, 'message' => 'wrong_greater_than')),
                         new GreaterThanOrEqual(array('value' => 5, 'message' => 'wrong_greater_than_or_equal')),
                         new IdenticalTo(array('value' => 5, 'message' => 'wrong_identical_to')),
@@ -491,13 +500,13 @@ class FunctionalTestsController extends BaseTestController
                         new Time(array('message' => 'wrong_time')),
                         new Date(array('message' => 'wrong_date')),
                         new DateTime(array('message' => 'wrong_date_time')),
-                        new True(array('message' => 'wrong_true')),
+                        new IsTrue(array('message' => 'wrong_true')),
                         new Type(array('type' => 'integer', 'message' => 'wrong_type')),
                         new Url(array('message' => 'wrong_url')),
                     )
                 )
             )
-            ->add('email', 'text', array())
+            ->add('email', TextType::class, array())
             ->getForm();
 
         $form->handleRequest($request);
@@ -528,13 +537,13 @@ class FunctionalTestsController extends BaseTestController
 
         $builder = $this
             ->createFormBuilder(null, array('js_validation' => (bool)$js))
-            ->add('enabled', 'text', $constraint('enabled_field'));
+            ->add('enabled', TextType::class, $constraint('enabled_field'));
 
         switch ($type) {
             case 'global':
                 break;
             case 'field':
-                $builder->add('disabled', 'text', $constraint('disabled_field'));
+                $builder->add('disabled', TextType::class, $constraint('disabled_field'));
                 break;
             default:
                 break;
@@ -575,7 +584,7 @@ class FunctionalTestsController extends BaseTestController
 
         $form = $this
             ->createFormBuilder(null, array('js_validation' => (bool)$js))
-            ->add('name', 'text', $constraint('enabled_field'))
+            ->add('name', TextType::class, $constraint('enabled_field'))
             ->getForm();
 
         $form->handleRequest($request);
@@ -599,7 +608,7 @@ class FunctionalTestsController extends BaseTestController
         $form   = $this->createFormBuilder($entity, array('js_validation' => (bool)$js))
             ->add('camel_case_field')
             ->add('camelCaseField')
-            ->add('submit', 'submit')
+            ->add('submit', SubmitType::class)
             ->getForm();
 
         $form->handleRequest($request);
@@ -615,7 +624,7 @@ class FunctionalTestsController extends BaseTestController
     public function customizationAction(Request $request, $type, $js)
     {
         $entity = new CustomizationEntity();
-        $form   = $this->createForm(new CustomizationType(), $entity, array('js_validation' => (bool)$js));
+        $form   = $this->createForm(CustomizationType::class, $entity, array('js_validation' => (bool)$js));
 
         $form->handleRequest($request);
 
@@ -630,7 +639,7 @@ class FunctionalTestsController extends BaseTestController
         $entity->setEmail('existing_email');
         $entity->setName('existing_name');
 
-        $form = $this->createForm(new UniqueType(), $entity);
+        $form = $this->createForm(UniqueType::class, $entity);
         $form->handleRequest($request);
         $tpl = 'DefaultTestBundle:FunctionalTests:index.html.twig';
 
@@ -644,7 +653,7 @@ class FunctionalTestsController extends BaseTestController
         $task->addComment(new CommentEntity());
 
         $form = $this->createForm(
-            new TaskType(),
+            TaskType::class,
             $task,
             array(
                 'attr' => array(
@@ -675,9 +684,8 @@ class FunctionalTestsController extends BaseTestController
             $entity->setCountries(array('france'));
             $entity->setContinent('europe');
         }
-
         $form = $this->createForm(
-            new EmtyChoiceType(),
+            EmptyChoiceType::class,
             $entity,
             array(
                 'js_validation' => (bool)$js
@@ -705,7 +713,7 @@ class FunctionalTestsController extends BaseTestController
         }
 
         $form   = $this->createForm(
-            new PasswordFieldType(),
+            PasswordFieldType::class,
             $entity,
             array(
                 'js_validation' => (bool)$js
@@ -728,7 +736,7 @@ class FunctionalTestsController extends BaseTestController
     {
         $passForm = $isValid;
         $onLoad   = $js;
-        $form     = $this->createForm(new AsyncLoadType(), null, array('attr' => array('novalidate' => true)));
+        $form     = $this->createForm(AsyncLoadType::class, null, array('attr' => array('novalidate' => true)));
         $form->handleRequest($request);
 
         if ('1' == $passForm) {

--- a/Tests/TestBundles/DefaultTestBundle/Entity/BasicConstraintsEntity.php
+++ b/Tests/TestBundles/DefaultTestBundle/Entity/BasicConstraintsEntity.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 use /** @noinspection PhpUnusedAliasInspection */
     Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity as BaseUniqueEntity;
-use Symfony\Component\Validator\ExecutionContextInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * Book
@@ -352,7 +352,7 @@ class BasicConstraintsEntity
 
     /**
      * @return bool
-     * @Assert\True(message="true_value")
+     * @Assert\IsTrue(message="true_value")
      */
     public function isTrue()
     {
@@ -361,7 +361,7 @@ class BasicConstraintsEntity
 
     /**
      * @return bool
-     * @Assert\False(message="false_value")
+     * @Assert\IsFalse(message="false_value")
      */
     public function isFalse()
     {
@@ -370,7 +370,7 @@ class BasicConstraintsEntity
 
     /**
      * @return bool
-     * @Assert\Null(message="null_{{ value }}")
+     * @Assert\IsNull(message="null_{{ value }}")
      */
     public function isNull()
     {
@@ -749,7 +749,7 @@ class BasicConstraintsEntity
     public function validateCallback(ExecutionContextInterface $context)
     {
         if (!$this->isValid) {
-            $context->addViolationAt('email', 'callback_email_' . $this->getEmail(), array(), null);
+            $context->buildViolation('callback_email_' . $this->getEmail())->atPath('email');
         }
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Entity/CustomizationEntity.php
+++ b/Tests/TestBundles/DefaultTestBundle/Entity/CustomizationEntity.php
@@ -4,7 +4,7 @@ namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\ExecutionContextInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * Book
@@ -189,7 +189,7 @@ class CustomizationEntity
     /**
      * @return bool
      *
-     * @Assert\True(
+     * @Assert\IsTrue(
      *     message="getter_message",
      *     groups={"groups_callback"}
      * )
@@ -207,7 +207,7 @@ class CustomizationEntity
      */
     public function validateCallback(ExecutionContextInterface $context)
     {
-        $context->addViolationAt('email', 'validate_callback_email_' . $this->getEmail());
+        $context->buildViolation('validate_callback_email_' . $this->getEmail())->atPath('email');
     }
 
     /**
@@ -215,7 +215,7 @@ class CustomizationEntity
      */
     public function ownCallback(ExecutionContextInterface $context)
     {
-        $context->addViolationAt('email', 'own_callback_email_' . $this->getEmail());
+        $context->buildViolation('own_callback_email_' . $this->getEmail())->atPath('email');
     }
 
     /**

--- a/Tests/TestBundles/DefaultTestBundle/Entity/TestEntity.php
+++ b/Tests/TestBundles/DefaultTestBundle/Entity/TestEntity.php
@@ -116,11 +116,11 @@ class TestEntity
 
     /**
      * @return bool
-     * @Assert\True(
+     * @Assert\IsTrue(
      *     message="getter_groups_array_message",
      *     groups={"groups_array"}
      * )
-     * @Assert\True(
+     * @Assert\IsTrue(
      *     message="getter_no_groups_message"
      * )
      */

--- a/Tests/TestBundles/DefaultTestBundle/Entity/TestSubEntity.php
+++ b/Tests/TestBundles/DefaultTestBundle/Entity/TestSubEntity.php
@@ -74,15 +74,15 @@ class TestSubEntity
 
     /**
      * @return bool
-     * @Assert\True(
+     * @Assert\IsTrue(
      *     message="sub_entity_getter_groups_child_message",
      *     groups={"groups_child"}
      * )
-     * @Assert\True(
+     * @Assert\IsTrue(
      *     message="sub_entity_getter_groups_array_message",
      *     groups={"groups_array"}
      * )
-     * @Assert\True(
+     * @Assert\IsTrue(
      *     message="sub_entity_getter_no_groups_message"
      * )
      */

--- a/Tests/TestBundles/DefaultTestBundle/Form/AsyncLoadType.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/AsyncLoadType.php
@@ -3,6 +3,8 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -21,21 +23,13 @@ class AsyncLoadType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', 'text', array(
+            ->add('name', TextType::class, array(
                 'constraints' => array(
                     new NotBlank(array(
                         'message' => 'async_load_message'
                     )),
                 )
             ))
-            ->add('submit', 'submit');
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'async_load';
+            ->add('submit', SubmitType::class);
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Form/BasicConstraintsEntityType.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/BasicConstraintsEntityType.php
@@ -3,6 +3,7 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,26 +27,18 @@ class BasicConstraintsEntityType extends AbstractType
             ->add('url')
             ->add('regex')
             ->add('ip')
-            ->add('time', 'text')
-            ->add('date', 'text')
-            ->add('datetime', 'text');
+            ->add('time', TextType::class)
+            ->add('date', TextType::class)
+            ->add('datetime', TextType::class);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\BasicConstraintsEntity',
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'form';
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Form/CommentType.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/CommentType.php
@@ -3,6 +3,7 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -20,24 +21,16 @@ class CommentType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('content', 'text');
+        $builder->add('content', TextType::class);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\CommentEntity',
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'form_comment';
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Form/CustomizationType.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/CustomizationType.php
@@ -3,6 +3,7 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -24,11 +25,11 @@ class CustomizationType extends AbstractType
             ->add('showErrors')
             ->add('callbackGroups')
             ->add('email')
-            ->add('submit', 'submit');
+            ->add('submit', SubmitType::class);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
@@ -43,14 +44,5 @@ class CustomizationType extends AbstractType
                 )
             )
         );
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-//        return 'form';
-        return 'custom_form_name';
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Form/EmptyChoiceType.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/EmptyChoiceType.php
@@ -3,6 +3,8 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -12,7 +14,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  *
  * @package Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form
  */
-class EmtyChoiceType extends AbstractType
+class EmptyChoiceType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder
@@ -22,13 +24,13 @@ class EmtyChoiceType extends AbstractType
     {
         $builder->add(
             'city',
-            'choice',
+            ChoiceType::class,
             array(
-                'empty_value' => 'Choose a City',
+                'placeholder' => 'Choose a City',
                 'choices'     => array(
-                    'london' => 'London',
-                    'paris'  => 'Paris',
-                    'berlin' => 'Berlin',
+                    'London' => 'london',
+                    'Paris'  => 'paris',
+                    'Berlin' => 'berlin',
                 ),
                 'multiple'    => false,
                 'expanded'    => false,
@@ -36,13 +38,13 @@ class EmtyChoiceType extends AbstractType
         )
         ->add(
             'countries',
-            'choice',
+            ChoiceType::class,
             array(
-                'empty_value' => 'Choose countries',
+                'placeholder' => 'Choose countries',
                 'choices'     => array(
-                    'france' => 'France',
-                    'spain'  => 'Spain',
-                    'germany' => 'Germany',
+                    'France' => 'france',
+                    'Spain'  => 'spain',
+                    'Germany' => 'germany',
                 ),
                 'multiple'    => true,
                 'expanded'    => true,
@@ -50,23 +52,23 @@ class EmtyChoiceType extends AbstractType
         )
         ->add(
             'continent',
-            'choice',
+            ChoiceType::class,
             array(
-                'empty_value' => 'Choose continent',
+                'placeholder' => 'Choose continent',
                 'choices' => array(
-                    'africa' => 'Africa',
-                    'asia'   => 'Asia',
-                    'europe' => 'Europe',
+                    'Africa' => 'africa',
+                    'Asia'   => 'asia',
+                    'Europe' => 'europe',
                 ),
                 'multiple' => false,
                 'expanded' => true,
             )
         )
-        ->add('submit', 'submit');
+        ->add('submit', SubmitType::class);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
@@ -78,13 +80,5 @@ class EmtyChoiceType extends AbstractType
                 )
             )
         );
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'form_choice';
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Form/PasswordFieldType.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/PasswordFieldType.php
@@ -3,6 +3,9 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -22,19 +25,19 @@ class PasswordFieldType extends AbstractType
     {
         $builder->add(
             'password',
-            'repeated',
+            RepeatedType::class,
             array(
-                'type' => 'password',
+                'type' => PasswordType::class,
                 'invalid_message' => 'diff_pass_message',
                 'first_options'  => array('label' => 'Password'),
                 'second_options' => array('label' => 'Repeat Password'),
             )
         )
-        ->add('submit', 'submit');
+        ->add('submit', SubmitType::class);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
@@ -46,13 +49,5 @@ class PasswordFieldType extends AbstractType
                 )
             )
         );
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'form_password_field';
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Form/TagType.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/TagType.php
@@ -3,6 +3,7 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -20,24 +21,16 @@ class TagType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('title', 'text');
+        $builder->add('title', TextType::class);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\TagEntity',
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'form_tag';
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Form/TaskType.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/TaskType.php
@@ -3,9 +3,12 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Valid;
 
 /**
  * Class TestFormType
@@ -22,41 +25,34 @@ class TaskType extends AbstractType
     {
         $builder->add(
             'tags',
-            'collection',
+            CollectionType::class,
             array(
-                'type'      => new TagType(),
-                'allow_add' => true,
+                'entry_type' => TagType::class,
+                'allow_add'  => true,
+                'constraints' => array(new Valid()),
             )
         )
         ->add(
             'comments',
-            'collection',
+            CollectionType::class,
             array(
-                'type'      => new CommentType(),
-                'allow_add' => true,
+                'entry_type' => CommentType::class,
+                'allow_add'  => true,
+                'constraints' => array(new Valid()),
             )
         )
-        ->add('submit', 'submit');
+        ->add('submit', SubmitType::class);
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
-                'cascade_validation' => true,
-                'data_class'         => 'Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\TaskEntity',
+                'data_class'  => 'Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\TaskEntity',
             )
         );
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'form_task';
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Form/TestFormType.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/TestFormType.php
@@ -3,6 +3,7 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -21,13 +22,13 @@ class TestFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', 'text', array(
+            ->add('name', TextType::class, array(
                 'constraints' => array(
                     new NotBlank(array(
                         'message' => 'form_no_groups_message'
                     )),
                     new NotBlank(array(
-                        'message' => 'form_groups_array_message',
+                        'message' => 'form_groups_array_message1',
                         'groups' => array('groups_array')
                     )),
                     new NotBlank(array(
@@ -40,20 +41,12 @@ class TestFormType extends AbstractType
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\TestEntity',
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'form';
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Form/TestFormTypeValidationFalse.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/TestFormTypeValidationFalse.php
@@ -3,6 +3,7 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -21,7 +22,7 @@ class TestFormTypeValidationFalse extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', 'text', array(
+            ->add('name', TextType::class, array(
                 'constraints' => array(
                     new NotBlank(array(
                         'message' => 'form_message'
@@ -31,20 +32,12 @@ class TestFormTypeValidationFalse extends AbstractType
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class'    => 'Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\TestEntity',
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'form_no_validation';
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Form/TestSubFormType.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/TestSubFormType.php
@@ -3,6 +3,7 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -21,7 +22,7 @@ class TestSubFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', 'text', array(
+            ->add('name', TextType::class, array(
                 'constraints' => array(
                     new NotBlank(array(
                         'message' => 'form_no_groups_message'
@@ -39,20 +40,12 @@ class TestSubFormType extends AbstractType
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\TestSubEntity',
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'form';
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Form/UniqueType.php
+++ b/Tests/TestBundles/DefaultTestBundle/Form/UniqueType.php
@@ -26,20 +26,12 @@ class UniqueType extends AbstractType
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\UniqueEntity',
         ));
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'form';
     }
 }

--- a/Tests/TestBundles/DefaultTestBundle/Resources/views/FunctionalTests/collection.html.twig
+++ b/Tests/TestBundles/DefaultTestBundle/Resources/views/FunctionalTests/collection.html.twig
@@ -5,9 +5,9 @@
         $(function () {
             function addPrototype(name) {
                 var prototype = $('#' + name + '_prototype').html();
-                var holderId = 'form_task_' + name + 's';
+                var holderId = 'task_' + name + 's';
                 var holder = $('#' + holderId);
-                var itemId = 'form_task_' + name + 's_';
+                var itemId = 'task_' + name + 's_';
                 var index = holder
                         .find('[id^=' + itemId + ']')
                         .filter(function () {
@@ -16,7 +16,7 @@
                         })
                         .length;
 
-                var delLink = $('<a href="#" class="del_form_task" id="del_form_task_' + name + 's_' + index + '">Delete tag</a>');
+                var delLink = $('<a href="#" class="del_task" id="del_task_' + name + 's_' + index + '">Delete tag</a>');
                 delLink.click(function () {
                     var id = $(this).prop('id').replace('del_', '');
                     $('#' + id).remove();

--- a/Tests/TestBundles/DefaultTestBundle/Resources/views/FunctionalTests/customization_jq.html.twig
+++ b/Tests/TestBundles/DefaultTestBundle/Resources/views/FunctionalTests/customization_jq.html.twig
@@ -3,11 +3,11 @@
 {% block body %}
     <script type="text/javascript">
         $(function(){
-            $('#custom_form_name_disabled').jsFormValidator({
+            $('#customization_disabled').jsFormValidator({
                 disabled: true
             });
 
-            $('#custom_form_name_showErrors').jsFormValidator({
+            $('#customization_showErrors').jsFormValidator({
                 showErrors: function(errors, type) {
                     var list = $(this).prev('ul.form-errors');
                     if (!list.length) {
@@ -37,7 +37,7 @@
                     for (var elId in errors) {
                         for (var sourceId in errors[elId]) {
                             var _err = errors[elId][sourceId];
-                            if ('custom_form_name_showErrors' == elId) {
+                            if ('customization_showErrors' == elId) {
                                 for (var i in _err) {
                                     _err[i] = 'custom_'+ errors[elId][sourceId][i];
                                 }
@@ -52,27 +52,27 @@
                         return false;
                     },
                     'validateCallback': function() {
-                        $('#custom_form_name_email').jsFormValidator('showErrors', {
+                        $('#customization_email').jsFormValidator('showErrors', {
                             errors: ['validate_callback_email_custom'],
                             sourceId: 'validate-callback'
                         });
                     },
                     'ownCallback': function() {
-                        $('#custom_form_name_email').jsFormValidator('showErrors', {
+                        $('#customization_email').jsFormValidator('showErrors', {
                             errors: ['own_callback_email_custom'],
                             sourceId: 'validate-callback-own'
                         });
                     },
                     'Fp\\JsFormValidatorBundle\\Tests\\TestBundles\\DefaultTestBundle\\Validator\\ExternalValidator': {
                         validateStaticCallback: function () {
-                            $('#custom_form_name_email').jsFormValidator('showErrors', {
+                            $('#customization_email').jsFormValidator('showErrors', {
                                 errors: ['static_callback_email_custom'],
                                 sourceId: 'static-validate-callback'
                             });
                         }
                     },
                     'validateDirectStaticCallback': function() {
-                        $('#custom_form_name_email').jsFormValidator('showErrors', {
+                        $('#customization_email').jsFormValidator('showErrors', {
                             errors: ['direct_static_callback_email_custom'],
                             sourceId: 'direct-static-validate-callback'
                         });

--- a/Tests/TestBundles/DefaultTestBundle/Resources/views/FunctionalTests/customization_js.html.twig
+++ b/Tests/TestBundles/DefaultTestBundle/Resources/views/FunctionalTests/customization_js.html.twig
@@ -7,12 +7,12 @@
     {{ form(form) }}
 
     <script type="text/javascript">
-        var field = document.getElementById('custom_form_name_disabled');
+        var field = document.getElementById('customization_disabled');
         FpJsFormValidator.customize(field, {
             disabled: true
         });
 
-        field = document.getElementById('custom_form_name_showErrors');
+        field = document.getElementById('customization_showErrors');
         FpJsFormValidator.customize(field, {
             showErrors: function(errors, type) {
                 if (!(this instanceof HTMLElement)) {
@@ -66,7 +66,7 @@
                 for (var elId in errors) {
                     for (var sourceId in errors[elId]) {
                         var _err = errors[elId][sourceId];
-                        if ('custom_form_name_showErrors' == elId) {
+                        if ('customization_showErrors' == elId) {
                             for (var i in _err) {
                                 _err[i] = 'custom_'+ errors[elId][sourceId][i];
                             }
@@ -82,14 +82,14 @@
                     return false;
                 },
                 'validateCallback': function() {
-                    var email = document.getElementById('custom_form_name_email');
+                    var email = document.getElementById('customization_email');
                     FpJsFormValidator.customize(email, 'showErrors', {
                         errors: ['validate_callback_email_custom'],
                         sourceId: 'validate-callback'
                     });
                 },
                 'ownCallback': function() {
-                    var email = document.getElementById('custom_form_name_email');
+                    var email = document.getElementById('customization_email');
                     FpJsFormValidator.customize(email, 'showErrors', {
                         errors: ['own_callback_email_custom'],
                         sourceId: 'validate-callback-own'
@@ -97,7 +97,7 @@
                 },
                 'Fp\\JsFormValidatorBundle\\Tests\\TestBundles\\DefaultTestBundle\\Validator\\ExternalValidator': {
                     validateStaticCallback: function () {
-                        var email = document.getElementById('custom_form_name_email');
+                        var email = document.getElementById('customization_email');
                         FpJsFormValidator.customize(email, 'showErrors', {
                             errors: ['static_callback_email_custom'],
                             sourceId: 'static-validate-callback'
@@ -105,7 +105,7 @@
                     }
                 },
                 'validateDirectStaticCallback': function() {
-                    var email = document.getElementById('custom_form_name_email');
+                    var email = document.getElementById('customization_email');
                     FpJsFormValidator.customize(email, 'showErrors', {
                         errors: ['direct_static_callback_email_custom'],
                         sourceId: 'direct-static-validate-callback'

--- a/Tests/TestBundles/DefaultTestBundle/Resources/views/FunctionalTests/index.html.twig
+++ b/Tests/TestBundles/DefaultTestBundle/Resources/views/FunctionalTests/index.html.twig
@@ -17,7 +17,7 @@
                 }
             });
 
-            $('#form_email').jsFormValidator({
+            $('#test_form_email').jsFormValidator({
                 'callbacks': {
                     'isNameValid': function() { return false; }
                 }

--- a/Tests/TestBundles/DefaultTestBundle/Twig/Extension/TestTwigExtension.php
+++ b/Tests/TestBundles/DefaultTestBundle/Twig/Extension/TestTwigExtension.php
@@ -12,9 +12,6 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 class TestTwigExtension extends \Twig_Extension
 {
-    /** @var  \Twig_Environment */
-    protected $env;
-
     /**
      * @var Kernel
      */
@@ -26,20 +23,12 @@ class TestTwigExtension extends \Twig_Extension
     }
 
     /**
-     * @param \Twig_Environment $environment
-     */
-    public function initRuntime(\Twig_Environment $environment)
-    {
-        $this->env = $environment;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFunctions()
     {
         return array(
-            'update_js_lib'  => new \Twig_Function_Method($this, 'updateJsLib'),
+            new \Twig_SimpleFunction('update_js_lib', array($this, 'updateJsLib')),
         );
     }
 

--- a/Tests/TestBundles/DefaultTestBundle/Validator/ExternalValidator.php
+++ b/Tests/TestBundles/DefaultTestBundle/Validator/ExternalValidator.php
@@ -2,7 +2,7 @@
 namespace Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Validator;
 
 use Fp\JsFormValidatorBundle\Tests\TestBundles\DefaultTestBundle\Entity\BasicConstraintsEntity;
-use Symfony\Component\Validator\ExecutionContextInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class ExternalValidator {
     /**
@@ -12,7 +12,7 @@ class ExternalValidator {
     public static function validateStaticCallback($object, ExecutionContextInterface $context)
     {
         if (!$object->isValid) {
-            $context->addViolationAt('email', 'static_callback_email_' . $object->getEmail(), array(), null);
+            $context->buildViolation('static_callback_email_' . $object->getEmail())->atPath('email');
         }
     }
 
@@ -23,7 +23,7 @@ class ExternalValidator {
     public static function validateDirectStaticCallback($object, ExecutionContextInterface $context)
     {
         if (!$object->isValid) {
-            $context->addViolationAt('email', 'direct_static_callback_email_' . $object->getEmail(), array(), null);
+            $context->buildViolation('direct_static_callback_email_' . $object->getEmail())->atPath('email');
         }
     }
 } 

--- a/Tests/app/AppKernel.php
+++ b/Tests/app/AppKernel.php
@@ -43,13 +43,6 @@ class AppKernel extends Kernel
     }
 
     /**
-     * An empty init function
-     */
-    public function init()
-    {
-    }
-
-    /**
      * @param string $name
      * @param string $extension
      */

--- a/Tests/app/Resources/config.php
+++ b/Tests/app/Resources/config.php
@@ -49,13 +49,12 @@ $container->loadFromExtension('framework', array(
     'fragments' => array(),
     'http_method_override' => true,
     'test' => true,
+    'assets' => array(),
 ));
 $container->loadFromExtension('twig', array(
     'debug' => true,
     'strict_variables' => true,
-    'form' => array(
-        'resources' => array('DefaultTestBundle::form_theme.html.twig')
-    ),
+    'form_themes' => array('DefaultTestBundle::form_theme.html.twig')
 ));
 $container->loadFromExtension('doctrine', array(
     'orm' => array(

--- a/Tests/app/index.php
+++ b/Tests/app/index.php
@@ -5,7 +5,8 @@ ini_set('display_errors', 1);
 set_error_handler(
     function ($code, $message, $file, $line) {
         throw new \ErrorException($message . ' in ' . $file . ' line ' . $line, $code);
-    }
+    },
+    E_ALL ^ E_USER_DEPRECATED
 );
 $env = 'dev';
 if (!empty($_SERVER['REQUEST_URI'])) {

--- a/Twig/Extension/JsFormValidatorTwigExtension.php
+++ b/Twig/Extension/JsFormValidatorTwigExtension.php
@@ -12,17 +12,6 @@ use Symfony\Component\Form\FormView;
  */
 class JsFormValidatorTwigExtension extends \Twig_Extension
 {
-    /** @var  \Twig_Environment */
-    protected $env;
-
-    /**
-     * @param \Twig_Environment $environment
-     */
-    public function initRuntime(\Twig_Environment $environment)
-    {
-        $this->env = $environment;
-    }
-
     /**
      * @var JsFormValidatorFactory
      */
@@ -53,8 +42,12 @@ class JsFormValidatorTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'init_js_validation'  => new \Twig_Function_Method($this, 'getJsValidator', array('is_safe' => array('html'))),
-            'js_validator_config' => new \Twig_Function_Method($this, 'getConfig', array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('init_js_validation', array($this, 'getJsValidator'), array(
+                'is_safe' => array('html')
+            )),
+            new \Twig_SimpleFunction('js_validator_config', array($this, 'getConfig'), array(
+                'is_safe' => array('html')
+            )),
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,27 @@
 
     ],
 
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/ruslan-polutsygan/MinkBundle"
+        }
+    ],
+
     "require": {
         "php": ">=5.3.2",
-        "symfony/form": ">=2.5",
-        "symfony/validator": ">=2.5.5"
+        "symfony/form": "^2.7|^3.0",
+        "symfony/validator": "^2.7|^3.0"
     },
 
     "require-dev": {
         "doctrine/orm": ">=2.2.3",
-        "doctrine/doctrine-bundle": "~1.2",
-        "symfony/symfony": ">=2.5.5",
+        "doctrine/doctrine-bundle": "~1.4",
+        "symfony/symfony": "^3.0",
         "symfony/assetic-bundle": ">=2.5",
         "phpunit/phpunit": "3.7.*",
         "behat/mink-bundle": "dev-master",
-        "behat/mink-selenium2-driver": "1.1.0",
+        "behat/mink-selenium2-driver": "^1.1.0",
         "satooshi/php-coveralls": "1.0.*",
         "se/selenium-server-standalone": "2.*",
         "ptcong/php-image-uploader": "^6.0"
@@ -51,7 +58,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.4-dev"
         }
     }
 }


### PR DESCRIPTION
Support for Symfony 3
I'm sorry this PR is so big but... :)

I have also created 1.3 branch which supports Symfony 2.7 and 2.8 but I cannot send a PR since this branch does not exist here. @66Ton99 Could you create it so I can send a PR?

The branch is here https://github.com/vaniocz/JsFormValidatorBundle/tree/1.3

There are probably some edge cases with the BC "layer" but since I fixed the build and all tests pass I think we can solve them in a future.