### PR TITLE
Pass whole type hierarchy to model

### DIFF
--- a/Factory/JsFormValidatorFactory.php
+++ b/Factory/JsFormValidatorFactory.php
@@ -11,6 +11,8 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\ChoicesToBooleanArrayT
 use Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToBooleanArrayTransformer;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\ResolvedFormTypeInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -65,7 +67,7 @@ class JsFormValidatorFactory
     /**
      * @param ValidatorInterface    $validator
      * @param TranslatorInterface   $translator
-     * @param \Symfony\Component\Routing\Generator\UrlGeneratorInterface $router
+     * @param UrlGeneratorInterface $router
      * @param array                 $config
      * @param string                $domain
      */
@@ -244,7 +246,7 @@ class JsFormValidatorFactory
         $model                 = new JsFormElement;
         $model->id             = $this->getElementId($form);
         $model->name           = $form->getName();
-        $model->type           = $conf->getType()->getInnerType()->getName();
+        $model->type           = $this->getFormTypeHierarchy($conf->getType());
         $model->invalidMessage = $this->translateMessage(
             $conf->getOption('invalid_message'),
             $conf->getOption('invalid_message_parameters')
@@ -262,6 +264,19 @@ class JsFormValidatorFactory
 
         // Return self id to add it as child to the parent model
         return $model;
+    }
+
+    private function getFormTypeHierarchy(ResolvedFormTypeInterface $formType)
+    {
+        $type = [
+            $formType->getName(),
+        ];
+
+        while ($formType = $formType->getParent()) {
+            $type[] = $formType->getName();
+        }
+
+        return $type;
     }
 
     /**

--- a/Factory/JsFormValidatorFactory.php
+++ b/Factory/JsFormValidatorFactory.php
@@ -268,9 +268,9 @@ class JsFormValidatorFactory
 
     private function getFormTypeHierarchy(ResolvedFormTypeInterface $formType)
     {
-        $type = [
+        $type = array(
             $formType->getName(),
-        ];
+        );
 
         while ($formType = $formType->getParent()) {
             $type[] = $formType->getName();

--- a/Resources/public/js/FpJsFormValidator.js
+++ b/Resources/public/js/FpJsFormValidator.js
@@ -375,6 +375,10 @@ var FpJsFormValidator = new function () {
     this.customizeMethods = new FpJsCustomizeMethods();
     this.constraintsCounter = 0;
 
+    function elementIsType(element, type) {
+        return element.type.indexOf(type) >= 0;
+    }
+
     //noinspection JSUnusedGlobalSymbols
     this.addModel = function (model, onLoad) {
         var self = this;
@@ -511,7 +515,7 @@ var FpJsFormValidator = new function () {
 
     this.checkParentCascadeOption = function (element) {
         var result = true;
-        if (element.parent && !element.parent.cascade && 'collection' != element.parent.type) {
+        if (element.parent && !element.parent.cascade && !elementIsType(element.parent, 'collection')) {
             result = false;
         } else if (element.parent) {
             result = this.checkParentCascadeOption(element.parent);
@@ -569,7 +573,7 @@ var FpJsFormValidator = new function () {
 
         if (i && undefined === value) {
             value = this.getMappedValue(element);
-        } else if ('collection' == element.type) {
+        } else if (elementIsType(element, 'collection')) {
             value = {};
             for (var childName in element.children) {
                 value[childName] = this.getMappedValue(element.children[childName]);
@@ -609,7 +613,7 @@ var FpJsFormValidator = new function () {
         }
 
         var value;
-        if ('checkbox' == element.type || 'radio' == element.type) {
+        if (elementIsType(element, 'checkbox') || elementIsType(element, 'radio')) {
             value = element.domNode.checked;
         } else if ('select' === element.domNode.tagName.toLowerCase()) {
             value = [];


### PR DESCRIPTION
Export whole form type hierarchy instead of just form type name. This allows to access validated value for custom form types based on their parent.

For example, the value of the `my_checkbox` field is accessed same as `checkbox`.
```
class MyCheckboxType extendsBastractType {
    public function getParent() {
        return 'checkbox';
    }

    public function getName() {
        return 'my_checkbox';
    }
}
```