### PR TITLE
Skip disabled fields

### DIFF
--- a/Resources/public/js/FpJsFormValidator.js
+++ b/Resources/public/js/FpJsFormValidator.js
@@ -20,7 +20,7 @@ function FpJsFormElement() {
     };
 
     this.validate = function () {
-        if (this.disabled) {
+        if (this.disabled || (this.domNode && this.domNode.disabled)) {
             return true;
         }
 

--- a/Resources/public/js/FpJsFormValidator.js
+++ b/Resources/public/js/FpJsFormValidator.js
@@ -20,12 +20,18 @@ function FpJsFormElement() {
     };
 
     this.validate = function () {
-        if (this.disabled || (this.domNode && this.domNode.disabled)) {
+        if (this.disabled) {
             return true;
         }
 
         var self = this;
         var sourceId = 'form-error-' + String(this.id).replace(/_/g, '-');
+        self.errors[sourceId] = [];
+
+        if (this.domNode && this.domNode.disabled) {
+            return true;
+        }
+
         self.errors[sourceId] = FpJsFormValidator.validateElement(self);
 
         var errorPath = FpJsFormValidator.getErrorPathElement(self);


### PR DESCRIPTION
Disabled fields should not be validated as they not user-editable (user can't produce invalid value) and they are event not send to server by the browser.