### PR TITLE
Fix issue "fp_js_formvalidator.js is missing"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ public function registerBundles()
 
 ### 1.3 Enable javascript libraries<a name="p_1_3"></a>
 
+#### 1.3.1 Add FpJsFormValidatorBundle to assetic bundles
+```yaml
+#app/config/config.yml
+
+assetic:
+    bundles:
+        - FpJsFormValidatorBundle
+```
+
+#### 1.3.2 Include the javascripts to your template
 ```twig
 <html>
     <head>

--- a/Resources/views/javascripts.html.twig
+++ b/Resources/views/javascripts.html.twig
@@ -1,3 +1,43 @@
-<script src="{{ asset('bundles/fpjsformvalidator/js/fp_js_validator.js') }}" type="text/javascript"></script>
+{% javascripts
+    '@FpJsFormValidatorBundle/Resources/public/js/FpJsFormValidator.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Blank.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Callback.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Choice.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Count.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Date.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/DateTime.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Email.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/EqualTo.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/GreaterThan.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/GreaterThanOrEqual.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/IdenticalTo.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Ip.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/IsFalse.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/False.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/IsNull.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/IsTrue.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Length.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/LessThan.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/LessThanOrEqual.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/NotBlank.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/NotEqualTo.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/NotIdenticalTo.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/NotNull.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Null.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Range.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Regex.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Time.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/True.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Type.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/UniqueEntity.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Url.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/constraints/Valid.js'
+    '@FpJsFormValidatorBundle/Resources/public/js/transformers/*'
+    '@FpJsFormValidatorBundle/Resources/public/js/jquery.fpjsformvalidator.js'
+    output="js/fp_js_formvalidator.js" combine=true %}
+
+    <script src="{{ asset_url }}"></script>
+{% endjavascripts %}
+
 {{ js_validator_config() }}
 {{ init_js_validation() }}

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/form": "^2.7|^3.0",
-        "symfony/validator": "^2.7|^3.0"
+        "symfony/validator": "^2.7|^3.0",
+        "symfony/assetic-bundle": ">=2.5"
     },
 
     "require-dev": {
         "doctrine/orm": ">=2.2.3",
         "doctrine/doctrine-bundle": "~1.4",
         "symfony/symfony": "^3.1",
-        "symfony/assetic-bundle": ">=2.5",
         "phpunit/phpunit": "3.7.*",
         "behat/mink-bundle": "dev-master",
         "behat/mink-selenium2-driver": "^1.1.0",


### PR DESCRIPTION
I updated the `javascripts.html.twig` file to make it use assetics, updated the `README.md` and moved the depedency `symfony/assetics` to the "require" section in `composer.json` instead of "require-dev"