### PR TITLE
added getExtendedTypes into FormExtension

### DIFF
--- a/src/Form/Extension/FormExtension.php
+++ b/src/Form/Extension/FormExtension.php
@@ -54,4 +54,12 @@ class FormExtension extends AbstractTypeExtension
     {
         return FormType::class;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getExtendedTypes()
+    {
+        yield FormType::class;
+    }
 }


### PR DESCRIPTION
This PR fixed deprication from Symfony 4.2

`Class "Fp\JsFormValidatorBundle\Form\Extension\FormExtension" should implement method "static Symfony\Component\Form\FormTypeExtensionInterface::getExtendedTypes()": Gets the extended types - not implementing it is deprecated since Symfony 4.2.`