### PR TITLE
adds instructions for Symfony 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 This module enables validation of the Symfony 4 or later forms on the JavaScript side.
 It converts form type constraints into JavaScript validation rules.
 
+If you have Symfony 4.* - you need to use [Version 1.6.x-dev](https://github.com/formapro/JsFormValidatorBundle/tree/1.6)
+
 If you have Symfony 3.1.* - you need to use [Version 1.5.*](https://github.com/formapro/JsFormValidatorBundle/tree/1.5)
 
 If you have Symfony 3.0.* - you need to use [Version 1.4.*](https://github.com/formapro/JsFormValidatorBundle/tree/1.4)


### PR DESCRIPTION
For Symfony 4 with "stable" as minimum stability requirements, one needs to use version `1.6.x-dev` in order for other dependencies to resolve properly. This PR adds a documentation line for that in the README.md.

Let me know if there is something I need to do here.

Cheers! Thanks for a great package!