### PR TITLE
fixed order of arguments in implode function

### DIFF
--- a/src/Model/JsModelAbstract.php
+++ b/src/Model/JsModelAbstract.php
@@ -54,7 +54,7 @@ abstract class JsModelAbstract
                 $jsObject[] = "'$paramName':" . self::phpValueToJs($paramValue);
             }
 
-            return sprintf('{%1$s}', implode($jsObject, ','));
+            return sprintf('{%1$s}', implode(',', $jsObject));
         }
         // For a sequential array
         elseif (is_array($value)) {
@@ -63,7 +63,7 @@ abstract class JsModelAbstract
                 $jsArray[] = self::phpValueToJs($item);
             }
 
-            return sprintf('[%1$s]', implode($jsArray, ','));
+            return sprintf('[%1$s]', implode(',', $jsArray));
         }
         // For string
         elseif (is_string($value)) {


### PR DESCRIPTION
This PR uses the preferred order of arguments in the `implode` function.

`implode()` can, for historical reasons, accept its parameters in either order, however, it is deprecated not to use the documented order of arguments and raises the deprecation notice in PHP 7.4.
(see https://www.php.net/manual/en/function.implode.php).
