### PR TITLE
[codex] Restore selected old PR fixes

### DIFF
--- a/Tests/Controller/AjaxControllerTest.php
+++ b/Tests/Controller/AjaxControllerTest.php
@@ -7,6 +7,7 @@ use Doctrine\Persistence\ObjectRepository;
 use Fp\JsFormValidatorBundle\Controller\AjaxController;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Class AjaxControllerTest
@@ -78,6 +79,16 @@ class AjaxControllerTest extends TestCase
         $this->expectException(\LogicException::class);
 
         $controller = new AjaxController();
+        $controller->checkUniqueEntityAction(new Request(array(), array()));
+    }
+
+    public function testUniqueEntityRequestDataIsRequired()
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $repository = new InMemoryRepository();
+        $controller = new AjaxController($this->createRegistry($repository));
+
         $controller->checkUniqueEntityAction(new Request(array(), array()));
     }
 

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -5,6 +5,7 @@ namespace Fp\JsFormValidatorBundle\Controller;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * These actions call from the client side to check some validations on the server side
@@ -41,7 +42,11 @@ class AjaxController
         }
 
         $data = $request->request->all();
-        $values = isset($data['data']) && is_array($data['data']) ? $data['data'] : array();
+        if (!array_key_exists('data', $data) || !is_array($data['data'])) {
+            throw new BadRequestHttpException('The "data" request field is required.');
+        }
+
+        $values = $data['data'];
         $ignoreNull = !empty($data['ignoreNull']);
 
         foreach ($values as $value) {

--- a/src/Resources/public/js/FpJsFormValidator.js
+++ b/src/Resources/public/js/FpJsFormValidator.js
@@ -307,8 +307,7 @@ function FpJsCustomizeMethods() {
         FpJsFormValidator.each(this, function (item) {
             var prototype = FpJsFormValidator.preparePrototype(
                 FpJsFormValidator.cloneObject(item.jsFormValidator.prototype),
-                name,
-                item.jsFormValidator.id + '_' + name
+                name
             );
             item.jsFormValidator.children[name] = FpJsFormValidator.createElement(prototype);
             item.jsFormValidator.children[name].parent = item.jsFormValidator;
@@ -960,6 +959,8 @@ var FpJsFormValidator = new function () {
      * @param {String} id
      */
     this.preparePrototype = function (prototype, name, id) {
+        id = typeof id === 'undefined' ? name : id;
+
         prototype.name = prototype.name.replace(/__name__/g, name);
         prototype.id = prototype.id.replace(/__name__/g, id);
 

--- a/src/Resources/public/js/FpJsFormValidator.test.js
+++ b/src/Resources/public/js/FpJsFormValidator.test.js
@@ -1,0 +1,55 @@
+import './FpJsFormValidator';
+
+describe('FpJsFormValidator prototypes', () => {
+    test('preparePrototype uses the prototype item name as the default id segment', () => {
+        const prototype = {
+            name: 'form[items][__name__]',
+            id: 'form_items___name__',
+            children: {
+                title: {
+                    name: 'form[items][__name__][title]',
+                    id: 'form_items___name___title',
+                    children: {},
+                },
+            },
+        };
+
+        const prepared = window.FpJsFormValidator.preparePrototype(prototype, '0');
+
+        expect(prepared.name).toBe('form[items][0]');
+        expect(prepared.id).toBe('form_items_0');
+        expect(prepared.children.title.name).toBe('form[items][0][title]');
+        expect(prepared.children.title.id).toBe('form_items_0_title');
+    });
+
+    test('addPrototype does not duplicate the parent id in generated child ids', () => {
+        const parent = window.FpJsFormValidator.createElement({
+            id: 'form_items',
+            name: 'form[items]',
+            type: '',
+            invalidMessage: '',
+            bubbling: false,
+            disabled: false,
+            transformers: [],
+            data: {},
+            children: {},
+            prototype: {
+                id: 'form_items___name__',
+                name: 'form[items][__name__]',
+                type: '',
+                invalidMessage: '',
+                bubbling: false,
+                disabled: false,
+                transformers: [],
+                data: {},
+                children: {},
+            },
+        });
+
+        window.FpJsFormValidator.customizeMethods.addPrototype.apply([{ jsFormValidator: parent }], ['0']);
+
+        expect(parent.children[0].id).toBe('form_items_0');
+        expect(parent.children[0].name).toBe('form[items][0]');
+        expect(parent.children[0].parent).toBe(parent);
+    });
+});


### PR DESCRIPTION
## What changed

- Ported the safe part of old PR #137 by rejecting malformed UniqueEntity Ajax requests that do not include the required `data` payload.
- Ported the safe part of old PR #141 by preventing collection prototype ids from duplicating the parent id prefix when `addPrototype()` creates a new child.
- Added PHPUnit coverage for malformed UniqueEntity Ajax requests.
- Added Jest regression coverage for `preparePrototype()` and `addPrototype()` id generation.

## Why

The old PRs were conflicting after the Symfony revival, but both contained small valid fixes that can be applied cleanly to the modernized codebase. These changes preserve the existing public behavior where possible: `preparePrototype()` still accepts an explicit id segment, but defaults to the item name when `addPrototype()` is the caller.

## Validation

- `php /tmp/jsfv-composer.phar validate --strict`
- `php /tmp/jsfv-composer.phar test`
- `npm test`
- `git diff --check`
