### PR TITLE
[codex] Expose UniqueEntity entity id

### DIFF
--- a/Tests/Unit/JsFormValidatorFactoryTest.php
+++ b/Tests/Unit/JsFormValidatorFactoryTest.php
@@ -4,7 +4,9 @@ namespace Fp\JsFormValidatorBundle\Tests\Unit;
 
 use Fp\JsFormValidatorBundle\Factory\JsFormValidatorFactory;
 use Fp\JsFormValidatorBundle\Form\Extension\FormExtension;
+use Fp\JsFormValidatorBundle\Form\Constraint\UniqueEntity as JsUniqueEntity;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity as SymfonyUniqueEntity;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
@@ -63,6 +65,45 @@ class JsFormValidatorFactoryTest extends TestCase
             $config->routing['check_unique_entity']
         );
     }
+
+    public function testUniqueEntityConstraintIncludesBoundEntityId()
+    {
+        $validator = Validation::createValidator();
+        $router = $this->createMock(UrlGeneratorInterface::class);
+        $factory = new JsFormValidatorFactory(
+            $validator,
+            new IdentityTranslator(),
+            $router,
+            array('js_validation' => true),
+            'validators'
+        );
+
+        $formFactory = Forms::createFormFactoryBuilder()
+            ->addExtension(new ValidatorExtension($validator))
+            ->addTypeExtension(new FormExtension($factory))
+            ->getFormFactory()
+        ;
+
+        $form = $formFactory
+            ->createBuilder(
+                FormType::class,
+                new UniqueEntityUser(15, 'john@example.com'),
+                array(
+                    'data_class' => UniqueEntityUser::class,
+                    'constraints' => array(new SymfonyUniqueEntity(fields: array('email'))),
+                )
+            )
+            ->add('email', TextType::class)
+            ->getForm()
+        ;
+
+        $model = $factory->createJsModel($form);
+        $constraints = $model->data['form']['constraints'][JsUniqueEntity::class];
+
+        $this->assertCount(1, $constraints);
+        $this->assertSame(15, $constraints[0]->entityId);
+        $this->assertSame(UniqueEntityUser::class, $constraints[0]->entityName);
+    }
 }
 
 class IdentityTranslator implements TranslatorInterface
@@ -79,5 +120,23 @@ class IdentityTranslator implements TranslatorInterface
     public function getLocale(): string
     {
         return 'en';
+    }
+}
+
+class UniqueEntityUser
+{
+    public $email;
+
+    private $id;
+
+    public function __construct($id, $email)
+    {
+        $this->id = $id;
+        $this->email = $email;
+    }
+
+    public function getId()
+    {
+        return $this->id;
     }
 }

--- a/src/Factory/JsFormValidatorFactory.php
+++ b/src/Factory/JsFormValidatorFactory.php
@@ -569,7 +569,11 @@ class JsFormValidatorFactory
             }
 
             if ($item instanceof \Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity) {
-                $item = new UniqueEntity($item, $this->currentElement->getConfig()->getDataClass());
+                $item = new UniqueEntity(
+                    $item,
+                    $this->currentElement->getConfig()->getDataClass(),
+                    $this->currentElement->getConfig()->getData()
+                );
             }
 
             $result[get_class($item)][] = $item;

--- a/src/Form/Constraint/UniqueEntity.php
+++ b/src/Form/Constraint/UniqueEntity.php
@@ -15,15 +15,32 @@ class UniqueEntity extends BaseUniqueEntity
     public $entityName = null;
 
     /**
+     * @var int|string|null
+     */
+    public $entityId = null;
+
+    /**
+     * @var mixed
+     */
+    protected $entity = null;
+
+    /**
      * @param BaseUniqueEntity $base
      * @param string           $entityName
+     * @param mixed            $entity
      */
-    public function __construct(BaseUniqueEntity $base, $entityName)
+    public function __construct(BaseUniqueEntity $base, $entityName, $entity = null)
     {
         $this->entityName = $entityName;
+        if (is_object($entity)) {
+            $this->entity = $entity;
+            if (method_exists($entity, 'getId')) {
+                $this->entityId = $entity->getId();
+            }
+        }
 
         foreach ($base as $prop => $value) {
             $this->{$prop} = $value;
         }
     }
-} 
+}

--- a/src/Resources/doc/3_9.md
+++ b/src/Resources/doc/3_9.md
@@ -53,10 +53,15 @@ $data = [
     'ignoreNull' => '1',
     'groups' => ['Default', 'User'],
     'entityName' => 'App\Entity\User',
+    'entityId' => 15,
     'data' => [
         'email' => 'john_doe@example.com',
     ],
 ];
 ```
+
+When the form is bound to an object that has a `getId()` method, `entityId`
+contains the current object id. Custom uniqueness controllers can use it to
+exclude the edited entity from their lookup.
 
 Return `true` when the value is unique and `false` when it is already used.

--- a/src/Resources/public/js/constraints/UniqueEntity.js
+++ b/src/Resources/public/js/constraints/UniqueEntity.js
@@ -11,6 +11,7 @@ export default function FpJsFormValidatorBundleFormConstraintUniqueEntity() {
     this.errorPath        = null;
     this.ignoreNull       = true;
     this.entityName       = null;
+    this.entityId         = null;
 
     this.groups           = [];
 
@@ -44,6 +45,7 @@ export default function FpJsFormValidatorBundleFormConstraintUniqueEntity() {
                 ignoreNull:       this.ignoreNull ? 1 : 0,
                 groups:           this.groups,
 
+                entityId:         this.entityId,
                 entityName:       this.entityName,
                 data:             this.getValues(element, this.fields)
             },

--- a/src/Resources/public/js/constraints/UniqueEntity.test.js
+++ b/src/Resources/public/js/constraints/UniqueEntity.test.js
@@ -1,0 +1,55 @@
+import '../FpJsFormValidator';
+import FpJsFormValidatorBundleFormConstraintUniqueEntity from './UniqueEntity';
+
+describe('FpJsFormValidatorBundleFormConstraintUniqueEntity', () => {
+    afterEach(() => {
+        window.FpJsFormValidator.config = {};
+        jest.restoreAllMocks();
+    });
+
+    test('sends the current entity id with the uniqueness request', () => {
+        const constraint = new FpJsFormValidatorBundleFormConstraintUniqueEntity();
+        constraint.fields = ['email'];
+        constraint.entityName = 'App\\Entity\\User';
+        constraint.entityId = 15;
+        constraint.uniqueId = 1;
+
+        window.FpJsFormValidator.config = {
+            routing: {
+                check_unique_entity: '/check_unique_entity',
+            },
+        };
+
+        const sendRequest = jest
+            .spyOn(window.FpJsFormValidator.ajax, 'sendRequest')
+            .mockImplementation(() => {});
+
+        const element = {
+            children: {
+                email: {
+                    name: 'email',
+                    type: '',
+                    transformers: [],
+                    children: {},
+                    domNode: {
+                        tagName: 'input',
+                        value: 'john@example.com',
+                    },
+                },
+            },
+        };
+
+        expect(constraint.validate(null, element)).toStrictEqual([]);
+        expect(sendRequest).toHaveBeenCalledWith(
+            '/check_unique_entity',
+            expect.objectContaining({
+                entityName: 'App\\Entity\\User',
+                entityId: 15,
+                data: {
+                    email: 'john@example.com',
+                },
+            }),
+            expect.any(Function),
+        );
+    });
+});


### PR DESCRIPTION
## What changed

- Ported the request-payload part of old PR #144 to the modernized codebase.
- When the form is bound to an object with `getId()`, the generated UniqueEntity JS constraint now includes `entityId`.
- The browser uniqueness request now sends `entityId` along with the existing UniqueEntity payload.
- Documented the `entityId` field for custom uniqueness controllers.
- Added PHPUnit coverage for generated UniqueEntity metadata and Jest coverage for the request payload.

## Scope note

The default AjaxController lookup is intentionally unchanged. Using `entityId` to exclude the currently edited entity depends on application-specific repository logic and identifier strategy, so the bundle exposes the id to custom controllers without making assumptions in the generic endpoint.

## Validation

- `php /tmp/jsfv-composer.phar validate --strict`
- `php /tmp/jsfv-composer.phar test`
- `npm test`
- `git diff --check`
