### PR TITLE
[codex] Fix GitHub coverage upload input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-code-coverage@v1
         with:
-          report: build/coverage/phpunit/cobertura.xml
+          file: build/coverage/phpunit/cobertura.xml
           language: PHP
           label: code-coverage/phpunit
 
@@ -163,7 +163,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-code-coverage@v1
         with:
-          report: build/coverage/jest/cobertura-coverage.xml
+          file: build/coverage/jest/cobertura-coverage.xml
           language: JavaScript
           label: code-coverage/jest
 


### PR DESCRIPTION
## Summary
- Fix the Coverage job failure from run `27006273124` by using the input expected by `actions/upload-code-coverage@v1`.
- Replace `report` with `file` for both PHP and JavaScript Cobertura uploads.

## Root Cause
`actions/upload-code-coverage@v1` warned that `report` is an unexpected input and only accepts `file`, `language`, `label`, `fail-on-error`, and `token`. Because `report` was ignored, `INPUT_FILE` was empty and the upload failed with `Coverage file not found:` after the coverage reports were generated successfully.

## Validation
- `git diff --check`
- `php /tmp/jsfv-composer.phar validate --strict`
- `php /tmp/jsfv-composer.phar test`
- `php /tmp/jsfv-composer.phar phpstan`
- `php /tmp/jsfv-composer.phar coverage`
- `npm run test:coverage`
- `npm test`
