### PR TITLE
[codex] Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,106 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "php"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      symfony:
+        patterns:
+          - "symfony/*"
+      doctrine:
+        patterns:
+          - "doctrine/*"
+      phpstan:
+        patterns:
+          - "phpstan/*"
+      phpunit:
+        patterns:
+          - "phpunit/*"
+          - "sebastian/*"
+          - "phar-io/*"
+          - "myclabs/deep-copy"
+          - "theseer/*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    versioning-strategy: "increase"
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      babel:
+        patterns:
+          - "@babel/*"
+      cypress:
+        patterns:
+          - "cypress"
+          - "@cypress/*"
+      jest:
+        patterns:
+          - "babel-jest"
+          - "jest"
+          - "jest-*"
+          - "@jest/*"
+
+  - package-ecosystem: "npm"
+    directory: "/Tests/app"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    versioning-strategy: "increase"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "test-app"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      webpack-encore:
+        patterns:
+          - "@symfony/webpack-encore"
+          - "webpack*"
+          - "*-loader"
+      test-app-runtime:
+        patterns:
+          - "core-js"
+          - "jquery"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with weekly version updates.
- Cover GitHub Actions, root Composer dependencies, root npm dependencies, and the `Tests/app` npm manifest.
- Group related dependency families to reduce PR noise.

## Notes
- Repository Dependabot alerts are already enabled.
- Repository automated security fixes are already enabled.
- npm uses `versioning-strategy: increase` because this repository does not commit npm lock files.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`
- `git diff --cached --check`
- `php /tmp/jsfv-composer.phar validate --strict`
