### PR TITLE
[codex] Update PHPUnit to 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This branch has been revived for the current PHP/Symfony baseline:
   8.6 nightly
 - Symfony 8.x components as declared in `composer.json`
 - Twig 3
-- PHPUnit 10/11
+- PHPUnit 13
 - PHPStan static analysis
 - PHP and JavaScript coverage thresholds
 - PSR-4 autoloading from `src/`

--- a/Tests/Controller/AjaxControllerTest.php
+++ b/Tests/Controller/AjaxControllerTest.php
@@ -94,7 +94,7 @@ class AjaxControllerTest extends TestCase
 
     private function createRegistry(ObjectRepository $repository)
     {
-        $registry = $this->createMock(ManagerRegistry::class);
+        $registry = $this->createStub(ManagerRegistry::class);
         $registry
             ->method('getRepository')
             ->willReturn($repository)

--- a/Tests/Unit/JsFormValidatorFactoryTest.php
+++ b/Tests/Unit/JsFormValidatorFactoryTest.php
@@ -29,6 +29,7 @@ class JsFormValidatorFactoryTest extends TestCase
         $validator = Validation::createValidator();
         $router = $this->createMock(UrlGeneratorInterface::class);
         $router
+            ->expects($this->once())
             ->method('generate')
             ->with('fp_js_form_validator.check_unique_entity')
             ->willReturn('/fp_js_form_validator/check_unique_entity')
@@ -75,7 +76,7 @@ class JsFormValidatorFactoryTest extends TestCase
     public function testUniqueEntityConstraintIncludesBoundEntityId()
     {
         $validator = Validation::createValidator();
-        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router = $this->createStub(UrlGeneratorInterface::class);
         $factory = new JsFormValidatorFactory(
             $validator,
             new IdentityTranslator(),
@@ -113,7 +114,7 @@ class JsFormValidatorFactoryTest extends TestCase
 
     public function testConfigModelKeepsMissingRoutesAsNull()
     {
-        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router = $this->createStub(UrlGeneratorInterface::class);
         $router
             ->method('generate')
             ->willReturnCallback(static function ($route) {
@@ -312,7 +313,7 @@ class JsFormValidatorFactoryTest extends TestCase
         $factory = new TestableJsFormValidatorFactory(
             Validation::createValidator(),
             new IdentityTranslator(),
-            $this->createMock(UrlGeneratorInterface::class),
+            $this->createStub(UrlGeneratorInterface::class),
             array('js_validation' => true),
             'validators'
         );
@@ -356,7 +357,7 @@ class JsFormValidatorFactoryTest extends TestCase
         array $config = array('js_validation' => true)
     ) {
         if (!$router) {
-            $router = $this->createMock(UrlGeneratorInterface::class);
+            $router = $this->createStub(UrlGeneratorInterface::class);
             $router
                 ->method('generate')
                 ->willReturn('/generated-route')

--- a/Tests/Unit/JsFormValidatorTwigExtensionTest.php
+++ b/Tests/Unit/JsFormValidatorTwigExtensionTest.php
@@ -11,7 +11,7 @@ class JsFormValidatorTwigExtensionTest extends TestCase
 {
     public function testRegistersTwigFunctions()
     {
-        $extension = new JsFormValidatorTwigExtension($this->createMock(JsFormValidatorFactory::class));
+        $extension = new JsFormValidatorTwigExtension($this->createStub(JsFormValidatorFactory::class));
 
         $functions = $extension->getFunctions();
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-symfony": "^2.0",
-        "phpunit/phpunit": "^10.5 || ^11.5",
+        "phpunit/phpunit": "^13.0",
         "symfony/asset": "^8.0",
         "symfony/console": "^8.0",
         "symfony/dotenv": "^8.0",


### PR DESCRIPTION
## Summary

- Require `phpunit/phpunit` `^13.0` for the PHP 8.4+ / Symfony 8 baseline.
- Update test doubles for PHPUnit 13: use stubs for passive doubles and add an explicit expectation for the `with()` call.
- Update the README status section to document PHPUnit 13.

## Validation

- `composer validate --strict`
- `composer test`
- `phpunit --display-phpunit-deprecations --display-phpunit-notices`
- `composer phpstan`
- `composer coverage`
- `git diff --check`
